### PR TITLE
Sundry changes to `README.txt`

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-Textpattern CMS 4.6.0
+Textpattern CMS 4.6-dev
 
 Released under the GNU General Public License.
 See LICENSE.txt for terms and conditions.
@@ -9,11 +9,16 @@ See LICENSE-LESSER.txt for terms and conditions.
 Includes contributions licensed under the New BSD License.
 See LICENSE-BSD-3.txt for terms and conditions.
 
+== About ==
+
+Textpattern CMS is a flexible, elegant and easy-to-use content management
+system. Textpattern is both free and open source.
+
 == Installation ==
 
 * Extract the files to your site (in the web root, or choose a
   subdirectory). The top-level index.php should reside in this
-  directory, as should the /textpattern/ and the /rpc/ directory.
+  directory, as should the /textpattern/ and the /rpc/ directories.
 * The .htaccess file, located in the root directory, is hidden by default
   on Mac OS X systems. Make sure this file is transferred across correctly
   to your install destination. Most FTP clients or IDEs will have an option
@@ -29,17 +34,16 @@ See LICENSE-BSD-3.txt for terms and conditions.
 * Log out of the admin-side.
 * Verify the existence of a working database and file backup.
 * Replace the three files in your main installation directory
-  (index.php, css.php and .htaccess), everything in your /rpc/ directory
-  and everything in your /textpattern/ directory (except config.php)
-  with the corresponding files in this distribution. css.php and /rpc/
-  might not yet exist in your current site.
+  (index.php, css.php and .htaccess), everything in your /js/ directory, 
+  everything in your /rpc/ directory and everything in your /textpattern/
+  directory (except config.php) with the corresponding files in this
+  distribution. css.php and /rpc/ might not yet exist in your current site.
 * It is recommended that you flush the cache of your browser, to ensure
   old cached files are not being used in preference to any newer versions
   within the upgrade.
 * When you log in to the admin-side, the relevant upgrade script is
-  run automatically. Please take a look into diagnostics to find out
-  whether there are any errors and whether the correct version number
-  is displayed.
+  run automatically. Please check the diagnostics to confirm the correct
+  version number is displayed and whether there are any errors.
   NOTE: Upgrades from versions prior to 4.2.0 will present this warning
   upon your very first login to the admin-side:
     Warning: Unknown column 'user_name' in 'where clause' select name,
@@ -60,10 +64,10 @@ See LICENSE-BSD-3.txt for terms and conditions.
    Google+:  http://textpattern.com/+
    Facebook: http://textpattern.com/facebook
 * If you are running an Apache web server, rename the .htaccess-dist file
-  in the /files directory to .htaccess to prohibit direct URL access to
+  in the /files/ directory to .htaccess to prohibit direct URL access to
   your files. Thus the only route to these files becomes through the
-  /file_download directory. We recommend you consider employing this feature
-  or that you move your /files directory out of a web-accessible location.
+  /file_download/ directory. We recommend you consider employing this feature
+  or that you move your /files/ directory out of a web-accessible location.
   Once moved, you can tell Textpattern of your new directory location from
   the Advanced Preferences.
 * There are additional resources for the default front-side theme, such as


### PR DESCRIPTION
- This is technically 4.6-dev and not 4.6.0, which might get confusing.
- Added an `About` overview.
- Pluralise `directory`
- Added reference to `/js/` directory
- Switched order of post-upgrade checks, tweaked language
- Trailing slash on directory names, per the opening paragraph
