### PR TITLE
Fix `ip` size for new instances and 4.6 upgrades

### DIFF
--- a/textpattern/setup/txpsql.php
+++ b/textpattern/setup/txpsql.php
@@ -163,7 +163,7 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_discuss` (
     `name` varchar(255) NOT NULL default '',
     `email` varchar(50) NOT NULL default '',
     `web` varchar(255) NOT NULL default '',
-    `ip` varchar(100) NOT NULL default '',
+    `ip` varchar(45) NOT NULL default '',
     `posted` datetime NOT NULL default '0000-00-00 00:00:00',
     `message` text NOT NULL,
     `visible` tinyint(4) NOT NULL default '1',
@@ -174,7 +174,7 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_discuss` (
 $create_sql[] = "INSERT INTO `".PFX."txp_discuss` VALUES (000001, 1, 'Donald Swain', 'donald.swain@example.com', 'example.com', '127.0.0.1', now() + interval 1 hour, '<p>I enjoy your site very much.</p>', 1)";
 
 $create_sql[] = "CREATE TABLE `".PFX."txp_discuss_ipban` (
-    `ip` varchar(255) NOT NULL default '',
+    `ip` varchar(45) NOT NULL default '',
     `name_used` varchar(255) NOT NULL default '',
     `date_banned` datetime NOT NULL default '0000-00-00 00:00:00',
     `banned_on_message` int(8) NOT NULL default '0',
@@ -275,7 +275,7 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_log` (
     `refer` mediumtext NOT NULL,
     `status` int(11) NOT NULL default '200',
     `method` varchar(16) NOT NULL default 'GET',
-    `ip` varchar(16) NOT NULL default '',
+    `ip` varchar(45) NOT NULL default '',
     PRIMARY KEY  (`id`),
     KEY `time` (`time`)
 ) $tabletype AUTO_INCREMENT=77 ";

--- a/textpattern/update/_to_4.6.0.php
+++ b/textpattern/update/_to_4.6.0.php
@@ -36,8 +36,10 @@ safe_update('txp_prefs', "position = '340'", "name = 'spam_blacklists'");
 // Updates comment email length.
 safe_alter('txp_discuss', "MODIFY email VARCHAR(254) NOT NULL default ''");
 
-// Store IPv6 properly in logs.
+// Store IPv6 properly in logs, discussions and discussion ban list.
 safe_alter('txp_log', "MODIFY ip VARCHAR(45) NOT NULL default ''");
+safe_alter('txp_discuss', "MODIFY ip VARCHAR(45) NOT NULL default ''");
+safe_alter('txp_discuss_ipban', "MODIFY ip VARCHAR(45) NOT NULL default ''");
 
 // Support for l10n string owners.
 $cols = getThings('describe `'.PFX.'txp_lang`');


### PR DESCRIPTION
Addresses https://github.com/textpattern/textpattern/issues/438

`ip` doesn’t need to be longer than 45 characters long. An IPv6 address with IPv4 tunnelling is the longest format at 45 characters. Brace yourself:

(6 \* 4 + 5) + 1 + (4 \* 3 + 3) = 29 + 1 + 15 = 45

With that in mind, three changes:
- Change `ip` in `txp_discuss` from 100 to 45
- Change `ip` in `txp_discuss_ipban` from 255 to 45
- Change `ip` in `txp_log` from 16 to 45

The change to `txp_log` does concern me a little. According to the 4.5.7 release notes, there is support for IPv6 in the logs, but `textpattern/setup/txpsql.php` only sets `ip` up for `varchar(16)`, which isn’t big enough for a full-fat IPv6 address. I’ll raise an issue.
