### PR TITLE
Add missing copyright/disclaimer headers

### DIFF
--- a/rpc/TXP_RPCServer.php
+++ b/rpc/TXP_RPCServer.php
@@ -1,10 +1,28 @@
 <?php
 
 /*
-XML-RPC Server for Textpattern 4.0.x
-http://txp.kusor.com/rpc-api
-(C)2005-2006 The Textpattern Development Team - http://textpattern.com
-@author Pedro Palazón - http://kusor.com
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * XML-RPC Server for Textpattern 4.0.x
+ * http://txp.kusor.com/rpc-api
+ *
+ * Copyright (C) 2005-2006, 2014 The Textpattern Development Team
+ * Author: Pedro Palazón - http://kusor.com
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
  */
 
 if (!defined('txpath')) die('txpath is undefined.');

--- a/rpc/index.php
+++ b/rpc/index.php
@@ -1,11 +1,29 @@
 <?php
 
 /*
-XML-RPC Server for Textpattern 4.0.x
-http://txp.kusor.com/rpc-api
-(C)2005-2006 The Textpattern Development Team - http://textpattern.com
-@author Pedro Palazón - http://kusor.com
-*/
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * XML-RPC Server for Textpattern 4.0.x
+ * http://txp.kusor.com/rpc-api
+ *
+ * Copyright (C) 2005-2006, 2014 The Textpattern Development Team
+ * Author: Pedro Palazón - http://kusor.com
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 // TODO: change error reporting to E_ALL, including E_NOTICE to detect subtle bugs?
 error_reporting(E_ALL & ~E_NOTICE);

--- a/textpattern/config-dist.php
+++ b/textpattern/config-dist.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 /**
  * Database credentials and site configuration.
  *

--- a/textpattern/css.php
+++ b/textpattern/css.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 /**
  * Outputs CSS files.
  *

--- a/textpattern/setup/en-gb.php
+++ b/textpattern/setup/en-gb.php
@@ -1,4 +1,26 @@
 <?php
+
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 # install en-gb without XML-RPC requirements
 $en_gb_lang = array(
     'admin' => array(

--- a/textpattern/setup/setup-langs.php
+++ b/textpattern/setup/setup-langs.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 // Generated: 04 Oct 2013, 10:18:32 GMT
 
 $langs = array(

--- a/textpattern/update/_to_1.0.0.php
+++ b/textpattern/update/_to_1.0.0.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }

--- a/textpattern/update/_to_4.0.2.php
+++ b/textpattern/update/_to_4.0.2.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }

--- a/textpattern/update/_to_4.0.3.php
+++ b/textpattern/update/_to_4.0.3.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }

--- a/textpattern/update/_to_4.0.4.php
+++ b/textpattern/update/_to_4.0.4.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }

--- a/textpattern/update/_to_4.0.5.php
+++ b/textpattern/update/_to_4.0.5.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }

--- a/textpattern/update/_to_4.0.6.php
+++ b/textpattern/update/_to_4.0.6.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }

--- a/textpattern/update/_to_4.0.7.php
+++ b/textpattern/update/_to_4.0.7.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }

--- a/textpattern/update/_to_4.0.8.php
+++ b/textpattern/update/_to_4.0.8.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }

--- a/textpattern/update/_to_4.2.0.php
+++ b/textpattern/update/_to_4.2.0.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }

--- a/textpattern/update/_to_4.3.0.php
+++ b/textpattern/update/_to_4.3.0.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }

--- a/textpattern/update/_to_4.4.0.php
+++ b/textpattern/update/_to_4.4.0.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }

--- a/textpattern/update/_to_4.4.1.php
+++ b/textpattern/update/_to_4.4.1.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }

--- a/textpattern/update/_to_4.5.0.php
+++ b/textpattern/update/_to_4.5.0.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }

--- a/textpattern/update/_to_4.5.7.php
+++ b/textpattern/update/_to_4.5.7.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 	if (!defined('TXP_UPDATE'))
 	{
 		exit("Nothing here. You can't access this file directly.");

--- a/textpattern/update/_to_4.6.0.php
+++ b/textpattern/update/_to_4.6.0.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }

--- a/textpattern/update/_update.php
+++ b/textpattern/update/_update.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!defined('TXP_UPDATE')) {
     exit("Nothing here. You can't access this file directly.");
 }


### PR DESCRIPTION
No changes to core code, just commented entries in Textpattern-created files. This adds a disclaimer to the existing files in `textpattern/update` because they make changes and don’t have an existing disclaimer.

Stuff in `rpc` is still credited to @kusor with appropriate author and documentation links - again, no changes to code, just some additional information and legal coverage. IANAL.
