### PR TITLE
IPv6 tweaks

### DIFF
--- a/textpattern/update/_to_4.5.8.php
+++ b/textpattern/update/_to_4.5.8.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * http://textpattern.com
+ *
+ * Copyright (C) 2014 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+	if (!defined('TXP_UPDATE'))
+	{
+		exit("Nothing here. You can't access this file directly.");
+	}
+
+	// Store IPv6 properly in discussions and discussion ban list.
+	safe_alter('txp_discuss', "MODIFY ip VARCHAR(45) NOT NULL default ''");
+	safe_alter('txp_discuss_ipban', "MODIFY ip VARCHAR(45) NOT NULL default ''");
+	


### PR DESCRIPTION
Upgraders will have `ip` fields in `txp_discuss` and `txp_discuss_ipban` revised to `VARCHAR(45)`.

On the grounds that new installs will process `txpsql.php` and then chew through the patches in `textpatten/update` (see http://forum.textpattern.com/viewtopic.php?pid=284631#p284631 for reference), `ip` in `txp_log` is taken care of by `_to_4.5.7.php` file. This update will take care of the other two places `ip` exists. There is (currently) no reference to `ip` in the `_to_4.6.0.php`, but if these changes belong in there instead, please advise and I'll raise a more appropriate PR.

This should resolve https://github.com/textpattern/textpattern/issues/442, which can be closed if this gets the thumbs up.
