### PR TITLE
Debug log: trace MemUsage

### DIFF
--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -5580,9 +5580,17 @@ function quote_list($in)
 function trace_add($msg)
 {
     global $production_status, $txptrace, $txptracelevel;
+    static $memory_last = 0;
 
     if ($production_status === 'debug') {
-        $txptrace[] = str_repeat("\t", $txptracelevel).$msg;
+        if (is_callable('memory_get_usage')) {
+            $memory_now = ceil(memory_get_usage()/1024);
+            $memory = sprintf("%7s |%6s |", $memory_now, ($memory_now > $memory_last) ? $memory_now - $memory_last : "");
+            $memory_last = $memory_now;
+        } else {
+            $memory = "";
+        }
+        $txptrace[] = $memory . str_repeat("\t", $txptracelevel) . $msg;
     }
 }
 

--- a/textpattern/publish.php
+++ b/textpattern/publish.php
@@ -628,7 +628,7 @@ function textpattern()
         echo maxMemUsage('end of textpattern()', 1);
 
         if (!empty($txptrace) and is_array($txptrace)) {
-            echo n, comment('txp tag trace: '.n.join(n, $txptrace).n);
+            echo n, comment('txp tag trace: '.n.'Mem(Kb)_|_+(Kb)_|_Trace___'.n.join(n, $txptrace).n);
         }
     }
 


### PR DESCRIPTION
This patch allows you to trace memory usage and help you find a Form/Tag/Plugin/SQL query that takes a lot of memory.

Forum thread
http://forum.textpattern.com/viewtopic.php?pid=292775#p292775