### PR TITLE
article_validate() returns immediately if message not empty. See #245

### DIFF
--- a/textpattern/include/txp_article.php
+++ b/textpattern/include/txp_article.php
@@ -2053,6 +2053,10 @@ function article_partial_value($rs, $key)
 
 function article_validate($rs, &$msg)
 {
+	if (!empty($msg)) {
+		return false;
+	}
+
     global $prefs, $step, $statuses;
 
     $constraints = array(


### PR DESCRIPTION
A quick fix to prevent expiry date inconsistencies and surprising messages/behaviours.