### PR TITLE
Option: Preload all forms in a single query

### DIFF
--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -4221,7 +4221,15 @@ function EvalElse($thing, $condition)
 
 function fetch_form($name)
 {
+    global $prefs;
     static $forms = array();
+
+    if (empty($forms) && !empty($prefs['enable_preload_form']) && !has_handler('form.fetch')) {
+        $rs = safe_rows('name, Form', 'txp_form', '1=1');
+        foreach ($rs as $r) {
+            $forms[$r['name']] = $r['Form'];
+        }
+    }
 
     $name = (string) $name;
 

--- a/textpattern/update/_to_4.6.0.php
+++ b/textpattern/update/_to_4.6.0.php
@@ -126,3 +126,8 @@ if (safe_field('name', 'txp_prefs', "name = 'ping_textpattern_com'")) {
 if (!get_pref('default_publish_status')) {
     set_pref('default_publish_status', STATUS_LIVE, 'publish', PREF_CORE, 'defaultPublishStatus', 15, PREF_PRIVATE);
 }
+
+// Add default enable_preload_form pref.
+if (!get_pref('enable_preload_form')) {
+    set_pref('enable_preload_form', 0, 'publish', PREF_CORE, 'yesnoradio', 330);
+}


### PR DESCRIPTION
I propose to allow the user to include preloading the forms yourself. (Admin / Preferences / Publish / `enable_preload_form` Pref. RadioButton: Yes/No)
Preloading all forms will be when you first load any form. Backward compatibility is completely satisfied, because do not change the call parameters `fetch_form()`.

Even on the default site(after Setup) saves 4 SQL query per page.
Counted for the page http:// ... /articles/1/welcome-to-your-site

http://forum.textpattern.com/viewtopic.php?id=39374