### PR TITLE
fix issue #250 and show correct error message.

### DIFF
--- a/textpattern/include/txp_category.php
+++ b/textpattern/include/txp_category.php
@@ -485,7 +485,7 @@ function cat_event_category_create($event)
     $name = strtolower(sanitizeForUrl($title));
 
     if (!$name) {
-        $message = array(gTxt($event.'_category_invalid', array('{name}' => $name)), E_ERROR);
+        $message = array(gTxt($event.'_category_invalid', array('{name}' => $title)), E_ERROR);
 
         return cat_category_list($message);
     }
@@ -568,11 +568,12 @@ function cat_event_category_save($event, $table_name)
     extract(doSlash(array_map('assert_string', psa(array('id', 'name', 'description', 'old_name', 'parent', 'title')))));
     $id = assert_int($id);
 
-    $name = sanitizeForUrl($name);
+    $rawname = $name;
+    $name = sanitizeForUrl($rawname);
 
     // Make sure the name is valid.
     if (!$name) {
-        $message = array(gTxt($event.'_category_invalid', array('{name}' => $name)), E_ERROR);
+        $message = array(gTxt($event.'_category_invalid', array('{name}' => $rawname)), E_ERROR);
 
         return cat_category_list($message);
     }

--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -2161,6 +2161,10 @@ function stripSpace($text, $force = false)
 /**
  * Sanitises a string for use in a URL.
  *
+ * Be aware that you still have to urlencode the string when appropriate. 
+ * This function just makes the string look prettier and excludes some
+ * unwanted characters, but leaves UTF-8 letters and digits intact.
+ *
  * @param  string $text The string
  * @return string
  * @package URL
@@ -2177,18 +2181,10 @@ function sanitizeForUrl($text)
     $in = $text;
     // Remove names entities and tags.
     $text = preg_replace("/(^|&\S+;)|(<[^>]*>)/U", "", dumbDown($text));
-    // Dashify high-order chars leftover from dumbDown().
-    $text = preg_replace("/[\x80-\xff]/", "-", $text);
-    // Collapse spaces, minuses, (back-)slashes and non-words.
-    $text = preg_replace('/[\s\-\/\\\\]+/', '-', trim(preg_replace('/[^\w\s\-\/\\\\]/', '', $text)));
-    // Remove all non-whitelisted characters
-    $text = preg_replace("/[^A-Za-z0-9\-_]/", "", $text);
-
-    // Sanitising shouldn't leave us with plain nothing to show.
-    // Fall back on percent-encoded URLs as a last resort for RFC 1738 conformance.
-    if (empty($text) || $text == '-') {
-        $text = rawurlencode($in);
-    }
+    // Remove all characters except letter, number, dash, space and backslash
+    $text = preg_replace('/[^\p{L}\p{N}\-_\s\/\\\\]/u', '', $text);
+    // Collapse spaces, minuses, (back-)slashes.
+    $text = trim(preg_replace('/[\s\-\/\\\\]+/', '-', $text), '-');
 
     return $text;
 }


### PR DESCRIPTION
Fixes issue #250 and shows the invalid name in the error message if a category cannot be created (instead of not showing it at all). See commit messages and issue #250 for more detail.