### PR TITLE
Allow prefetch_forms via plugin

### DIFF
--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -4192,7 +4192,7 @@ function EvalElse($thing, $condition)
 
 function fetch_form($name)
 {
-    static $forms = array();
+    global $forms;
 
     $name = (string) $name;
 

--- a/textpattern/publish.php
+++ b/textpattern/publish.php
@@ -54,6 +54,7 @@ set_error_handler('publicErrorHandler', error_reporting());
 
 ob_start();
 
+$forms = array();
 $txp_current_tag = '';
 
 // Get all prefs as an array.


### PR DESCRIPTION
Change type variable `$forms` from `static` to `global`.
This will make using plugin preload forms of sql / file system / other source.

Discussion: http://forum.textpattern.com/viewtopic.php?id=39374

ps: Perhaps it will be useful for `themes branche` (preload theme forms).