### PR TITLE
Fix undefined variable: listform

### DIFF
--- a/textpattern/publish.php
+++ b/textpattern/publish.php
@@ -934,7 +934,7 @@ function doArticles($atts, $iscustom, $thing = null)
     if ($q and !$iscustom and !$issticky) {
         $fname = ($searchform ? $searchform : 'search_results');
     } else {
-        $fname = ($listform ? $listform : $form);
+        $fname = (!empty($listform) ? $listform : $form);
     }
 
     if ($rs) {


### PR DESCRIPTION
Fix minor bug after pull request https://github.com/textpattern/textpattern/pull/511

Reproduce bug:  `<txp:article_custom form="article_listing" />`

Error:
`Tag error: <txp:article_custom form="article_listing" /> ->  Notice: Undefined variable: listform while parsing form default on page archive`