### PR TITLE
Trace log: Nesting forms

### DIFF
--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -4243,6 +4243,7 @@ function parse_form($name)
 
         $old_form = $txp_current_form;
         $txp_current_form = $stack[] = $name;
+        trace_add("[Nesting forms: '".join("' / '", $stack)."']");
         $out = parse($f);
         $txp_current_form = $old_form;
         array_pop($stack);


### PR DESCRIPTION
Sometimes, sites with a large number of forms can be difficult to find what form is called from.
This patch shows the nesting of forms in the trace log.

Sample output:
```
<txp:output_form form="subitem_list" />
	[Form: 'subitem_list']
	[Nesting forms: 'default' / 'article_listing' / 'subitem_list']
```
