### PR TITLE
Escape double dash sequences inside comments...

### DIFF
--- a/textpattern/lib/txplib_html.php
+++ b/textpattern/lib/txplib_html.php
@@ -1076,7 +1076,6 @@ function htmlPre($item, $atts = '')
 
 function comment($item)
 {
-    // Note that the replacement string is two &#8208 characters
     return '<!-- '.str_replace('--', '- - ', $item).' -->';
 }
 

--- a/textpattern/lib/txplib_html.php
+++ b/textpattern/lib/txplib_html.php
@@ -1077,7 +1077,7 @@ function htmlPre($item, $atts = '')
 function comment($item)
 {
     // Note that the replacement string is two &#8208 characters
-    return '<!-- '.str_replace('--', '‐‐', $item).' -->';
+    return '<!-- '.str_replace('--', '- - ', $item).' -->';
 }
 
 /**

--- a/textpattern/lib/txplib_html.php
+++ b/textpattern/lib/txplib_html.php
@@ -1076,7 +1076,8 @@ function htmlPre($item, $atts = '')
 
 function comment($item)
 {
-    return '<!-- '.str_replace('-->', '&shy;&shy;>', $item).' -->';
+    // Note that the replacement string is two &#8208 characters
+    return '<!-- '.str_replace('--', '‐‐', $item).' -->';
 }
 
 /**


### PR DESCRIPTION
...because they signify an interruption in the comment text, which otherwise could be visible to people visiting the website