### PR TITLE
update tagbuilder after changes in comments_form tags

### DIFF
--- a/textpattern/include/txp_tag.php
+++ b/textpattern/include/txp_tag.php
@@ -1084,7 +1084,22 @@ class Textpattern_Tag_BuilderTags
 
     function tag_comment_email_input()
     {
-        return $this->tbNoAtts();
+        $atts = gpsa(array(
+            'size',
+        ));
+
+        extract($atts);
+
+        $out = $this->tagbuildForm(
+            $this->startblock.
+            $this->widgets(array(
+                'input_size'   => $this->tbInput('size', $size, INPUT_TINY),
+            )).
+            $this->endform
+        ).
+        $this->build($atts);
+
+        return $out;
     }
 
     /**
@@ -1102,7 +1117,24 @@ class Textpattern_Tag_BuilderTags
 
     function tag_comment_message_input()
     {
-        return $this->tbNoAtts();
+        $atts = gpsa(array(
+            'cols',
+            'rows',
+        ));
+
+        extract($atts);
+
+        $out = $this->tagbuildForm(
+            $this->startblock.
+            $this->widgets(array(
+                'msgcols' => $this->tbInput('cols', $cols, INPUT_TINY),
+                'msgrows' => $this->tbInput('rows', $rows, INPUT_TINY),
+            )).
+            $this->endform
+        ).
+        $this->build($atts);
+
+        return $out;
     }
 
     /**
@@ -1133,7 +1165,22 @@ class Textpattern_Tag_BuilderTags
 
     function tag_comment_name_input()
     {
-        return $this->tbNoAtts();
+        $atts = gpsa(array(
+            'size',
+        ));
+
+        extract($atts);
+
+        $out = $this->tagbuildForm(
+            $this->startblock.
+            $this->widgets(array(
+                'input_size'   => $this->tbInput('size', $size, INPUT_TINY),
+            )).
+            $this->endform
+        ).
+        $this->build($atts);
+
+        return $out;
     }
 
     /**
@@ -1215,7 +1262,22 @@ class Textpattern_Tag_BuilderTags
 
     function tag_comment_web_input()
     {
-        return $this->tbNoAtts();
+        $atts = gpsa(array(
+            'size',
+        ));
+
+        extract($atts);
+
+        $out = $this->tagbuildForm(
+            $this->startblock.
+            $this->widgets(array(
+                'input_size'   => $this->tbInput('size', $size, INPUT_TINY),
+            )).
+            $this->endform
+        ).
+        $this->build($atts);
+
+        return $out;
     }
 
     /**
@@ -1261,12 +1323,8 @@ class Textpattern_Tag_BuilderTags
     function tag_comments_form()
     {
         $atts = gpsa(array(
-            'class',
             'id',
-            'isize',
             'form',
-            'msgcols',
-            'msgrows',
             'wraptag',
         ));
 
@@ -1276,12 +1334,8 @@ class Textpattern_Tag_BuilderTags
             $this->startblock.
             $this->widgets(array(
                 'id'      => $this->tbInput('id', $id),
-                'isize'   => $this->tbInput('isize', $isize, INPUT_TINY),
-                'msgcols' => $this->tbInput('msgcols', $msgcols, INPUT_TINY),
-                'msgrows' => $this->tbInput('msgrows', $msgrows, INPUT_TINY),
                 'form'    => $this->tbFormPop('form', 'comment', $form),
                 'wraptag' => $this->tbInput('wraptag', $wraptag),
-                'class'   => $this->tbInput('class', $class, INPUT_REGULAR),
             )).
             $this->endform
         ).

--- a/textpattern/lang/en-gb.txt
+++ b/textpattern/lang/en-gb.txt
@@ -1092,7 +1092,6 @@ id => ID#
 include_default => Include default section?
 inline_style => Inline style (CSS)
 input_size => Input size
-isize => Input size
 labeltag => Label tag
 limit => Display how many?
 linkclass => CSS class for links

--- a/textpattern/setup/en-gb.php
+++ b/textpattern/setup/en-gb.php
@@ -1135,7 +1135,6 @@ $en_gb_lang = array(
         'include_default' => 'Include default section?',
         'inline_style' => 'Inline style (CSS)',
         'input_size' => 'Input size',
-        'isize' => 'Input size',
         'labeltag' => 'Label tag',
         'limit' => 'Display how many?',
         'linkclass' => 'CSS class for links',


### PR DESCRIPTION
A lot of attributes were not available through the tagbuilder, so I only moved the ones that were already there so the tagbuilder at least doesn't create tags with deprecated attributes (due to fixed issue #29).

Is the tagbuilder scheduled for removal or is there still commitment to keep it in TXP?