### PR TITLE
Add container ability to comment tags that have form attribute

### DIFF
--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -2134,7 +2134,7 @@ function comments_invite($atts)
 
 // -------------------------------------------------------------
 
-function popup_comments($atts)
+function popup_comments($atts, $thing = null)
 {
     extract(lAtts(array(
         'form' => 'comments_display'
@@ -2148,9 +2148,7 @@ function popup_comments($atts)
 
     if ($rs) {
         populateArticleData($rs);
-        $result = parse_form($form);
-
-        return $result;
+        return ($thing === null ? parse_form($form) : parse($thing));
     }
 
     return '';
@@ -2158,7 +2156,7 @@ function popup_comments($atts)
 
 // -------------------------------------------------------------
 
-function comments_form($atts)
+function comments_form($atts, $thing = null)
 {
     global $thisarticle, $has_comments_preview;
     global $thiscommentsform; // TODO: Remove any uses of $thiscommentsform when removing deprecated attributes from below.
@@ -2243,7 +2241,7 @@ function comments_form($atts)
 
         $out .= '<form id="txpCommentInputForm" method="post" action="'.txpspecialchars($url).'#cpreview">'.
             n.'<div class="comments-wrapper">'.n. // Prevent XHTML Strict validation gotchas.
-            parse_form($form).
+            ($thing === null ? parse_form($form) : parse($thing)).
             n.hInput('parentid', ($parentid ? $parentid : $thisid)).
             n.hInput('backpage', (ps('preview') ? $backpage : $url)).
             n.'</div>'.
@@ -2527,7 +2525,7 @@ function comments_annotateinvite($atts, $thing)
 
 // -------------------------------------------------------------
 
-function comments($atts)
+function comments($atts, $thing = null)
 {
     global $thisarticle, $prefs;
     extract($prefs);
@@ -2570,7 +2568,7 @@ function comments($atts)
 
         while ($vars = nextRow($rs)) {
             $GLOBALS['thiscomment'] = $vars;
-            $comments[] = parse_form($form).n;
+            $comments[] = ($thing === null ? parse_form($form) : parse($thing)).n;
             unset($GLOBALS['thiscomment']);
         }
 
@@ -2582,7 +2580,7 @@ function comments($atts)
 
 // -------------------------------------------------------------
 
-function comments_preview($atts)
+function comments_preview($atts, $thing = null)
 {
     global $has_comments_preview;
 
@@ -2615,7 +2613,7 @@ function comments_preview($atts)
     $preview['web'] = clean_url($preview['web']);
 
     $GLOBALS['thiscomment'] = $preview;
-    $comments = parse_form($form).n;
+    $comments = ($thing === null ? parse_form($form) : parse($thing)).n;
     unset($GLOBALS['thiscomment']);
     $out = doTag($comments, $wraptag, $class);
 


### PR DESCRIPTION
This affects the following tags: 
* popup_comments
* comments_form
* comments
* comments_preview

If this pull request is accepted, an issue should be opened on the documentation repository to document this change and the fact that we have a popup_comments tag (not documented yet).