### PR TITLE
Default to charset utf8mb4

### DIFF
--- a/textpattern/setup/index.php
+++ b/textpattern/setup/index.php
@@ -382,17 +382,23 @@ function printConfig()
         exit;
     }
 
-    // On 4.1 or greater use UTF-8-tables.
-    $version = mysqli_get_server_info($mylink);
-
-    if (version_compare($version, '4.1') >= 0) {
-        if (mysqli_query($mylink, "SET NAMES utf8")) {
-            $_SESSION['dbcharset'] = "utf8";
-        } else {
-            $_SESSION['dbcharset'] = "latin1";
-        }
+    // On MySQL 5.5.3+ use real UTF-8 tables, if the client supports it.
+    $_SESSION['dbcharset'] = "utf8mb4";
+    // Lower versions only support UTF-8 limited to 3 bytes per character
+    if (mysqli_get_server_version($mylink) < 50503) {
+        $_SESSION['dbcharset'] = "utf8";
     } else {
-        $_SESSION['dbcharset'] = "latin1";
+        if (FALSE !== strpos(mysqli_get_client_info($mylink), 'mysqlnd')) {
+            // mysqlnd 5.0.9+ required
+            if (mysqli_get_client_version($mylink) < 50009) {
+                $_SESSION['dbcharset'] = "utf8";
+            }
+        } else {
+            // libmysqlclient 5.5.3+ required
+            if (mysqli_get_client_version($mylink) < 50503) {
+                $_SESSION['dbcharset'] = "utf8";
+            }
+        }
     }
 
     echo graf(

--- a/textpattern/setup/txpsql.php
+++ b/textpattern/setup/txpsql.php
@@ -60,7 +60,9 @@ $tabletype = (version_compare($version, '4.1.2') >= 0) ? ' ENGINE=MyISAM ' : ' T
 if (isset($dbcharset)) {
     $tabletype .= " CHARACTER SET = $dbcharset ";
 
-    if ($dbcharset == 'utf8') {
+    if ($dbcharset == 'utf8mb4') {
+        $tabletype .= " COLLATE utf8mb4_unicode_ci ";
+    } elseif ($dbcharset == 'utf8') {
         $tabletype .= " COLLATE utf8_general_ci ";
     }
 
@@ -112,7 +114,7 @@ $create_sql[] = "CREATE TABLE `".PFX."textpattern` (
     `Status` int(2) NOT NULL default '4',
     `textile_body` int(2) NOT NULL default '1',
     `textile_excerpt` int(2) NOT NULL default '1',
-    `Section` varchar(64) NOT NULL default '',
+    `Section` varchar(255) NOT NULL default '',
     `override_form` varchar(255) NOT NULL default '',
     `Keywords` varchar(255) NOT NULL default '',
     `url_title` varchar(255) NOT NULL default '',
@@ -161,7 +163,7 @@ $create_sql[] = "INSERT INTO `".PFX."txp_category` VALUES (8, 'textpattern', 'li
 $create_sql[] = "CREATE TABLE `".PFX."txp_css` (
     `name` varchar(255) NOT NULL,
     `css` text NOT NULL,
-    UNIQUE KEY `name` (`name`)
+    UNIQUE KEY `name` (`name`(250))
 ) $tabletype ";
 
 // sql:txp_css
@@ -190,7 +192,7 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_discuss_ipban` (
     `name_used` varchar(255) NOT NULL default '',
     `date_banned` datetime NOT NULL default '0000-00-00 00:00:00',
     `banned_on_message` int(8) NOT NULL default '0',
-    PRIMARY KEY (`ip`)
+    PRIMARY KEY (`ip`(250))
 ) $tabletype ";
 
 $create_sql[] = "CREATE TABLE `".PFX."txp_discuss_nonce` (
@@ -198,7 +200,7 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_discuss_nonce` (
     `nonce` varchar(255) NOT NULL default '',
     `used` tinyint(4) NOT NULL default '0',
     `secret` varchar(255) NOT NULL default '',
-    PRIMARY KEY (`nonce`)
+    PRIMARY KEY (`nonce`(250))
 ) $tabletype ";
 
 $create_sql[] = "CREATE TABLE `".PFX."txp_file` (
@@ -209,14 +211,14 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_file` (
     `description` text NOT NULL,
     `downloads` int(4) unsigned NOT NULL default '0',
     PRIMARY KEY  (`id`),
-    UNIQUE KEY `filename` (`filename`)
+    UNIQUE KEY `filename` (`filename`(250))
 ) $tabletype PACK_KEYS=0 AUTO_INCREMENT=1 ";
 
 $create_sql[] = "CREATE TABLE `".PFX."txp_form` (
-    `name` varchar(64) NOT NULL default '',
+    `name` varchar(255) NOT NULL default '',
     `type` varchar(28) NOT NULL default '',
     `Form` text NOT NULL,
-    PRIMARY KEY (`name`)
+    PRIMARY KEY (`name`(250))
 ) $tabletype PACK_KEYS=1";
 
 // sql:txp_form
@@ -292,9 +294,9 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_log` (
 ) $tabletype AUTO_INCREMENT=77 ";
 
 $create_sql[] = "CREATE TABLE `".PFX."txp_page` (
-    `name` varchar(128) NOT NULL default '',
+    `name` varchar(255) NOT NULL default '',
     `user_html` text NOT NULL,
-    PRIMARY KEY (`name`)
+    PRIMARY KEY (`name`(250))
 ) $tabletype PACK_KEYS=1";
 
 // sql:txp_page
@@ -327,7 +329,7 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_prefs` (
     `html` varchar(64) NOT NULL default 'text_input',
     `position` smallint(5) unsigned NOT NULL default '0',
     `user_name` varchar(64) NOT NULL default '',
-    UNIQUE KEY `prefs_idx` (`prefs_id`,`name`, `user_name`),
+    UNIQUE KEY `prefs_idx` (`prefs_id`,`name`(185), `user_name`),
     KEY `name` (`name`),
     KEY `user_name` (`user_name`)
 ) $tabletype ";
@@ -422,7 +424,7 @@ $create_sql[] = "INSERT INTO `".PFX."txp_prefs` VALUES (1, 'version', '1.0rc4', 
 $create_sql[] = "INSERT INTO `".PFX."txp_prefs` VALUES (1, 'doctype', 'html5', 0, 'publish', 'doctypes', 190, '')";
 
 $create_sql[] = "CREATE TABLE `".PFX."txp_section` (
-    `name` varchar(128) NOT NULL default '',
+    `name` varchar(255) NOT NULL default '',
     `page` varchar(128) NOT NULL default '',
     `css` varchar(128) NOT NULL default '',
     `is_default` int(2) NOT NULL default '0',
@@ -430,7 +432,7 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_section` (
     `on_frontpage` int(2) NOT NULL default '1',
     `searchable` int(2) NOT NULL default '1',
     `title` varchar(255) NOT NULL default '',
-    PRIMARY KEY (`name`)
+    PRIMARY KEY (`name`(250))
 ) $tabletype PACK_KEYS=1";
 
 $create_sql[] = "INSERT INTO `".PFX."txp_section` VALUES ('articles', 'archive', 'default', 1, 1, 1, 1, 'Articles')";

--- a/textpattern/update/_to_4.0.4.php
+++ b/textpattern/update/_to_4.0.4.php
@@ -50,7 +50,7 @@ foreach ($rs as $row) {
 }
 
 if (!$has_ss_idx) {
-    safe_query('alter ignore table `'.PFX.'textpattern` add index section_status_idx (Section,Status)');
+    safe_query('alter ignore table `'.PFX.'textpattern` add index section_status_idx (Section(249),Status)');
 }
 
 if (!safe_field('name', 'txp_prefs', "name = 'title_no_widow'")) {

--- a/textpattern/update/_to_4.2.0.php
+++ b/textpattern/update/_to_4.2.0.php
@@ -29,7 +29,7 @@ if (!defined('TXP_UPDATE')) {
 $cols = getThings('describe `'.PFX.'txp_prefs`');
 if (!in_array('user_name', $cols)) {
     safe_alter('txp_prefs',
-    "ADD `user_name` varchar(64) NOT NULL default '', DROP INDEX `prefs_idx`, ADD UNIQUE `prefs_idx` (`prefs_id`, `name`, `user_name`), ADD INDEX `user_name` (`user_name`)");
+    "ADD `user_name` varchar(64) NOT NULL default '', DROP INDEX `prefs_idx`, ADD UNIQUE `prefs_idx` (`prefs_id`, `name`(185), `user_name`), ADD INDEX `user_name` (`user_name`)");
 }
 
 // Remove a few global prefs in favour of future private ones.
@@ -89,7 +89,7 @@ foreach (array('txp_file', 'txp_link') as $table) {
     $cols = getThings('describe `'.PFX.$table.'`');
 
     if (!in_array('author', $cols)) {
-        safe_alter($table, "ADD author varchar(255) NOT NULL default '', ADD INDEX author_idx (author)");
+        safe_alter($table, "ADD author varchar(64) NOT NULL default '', ADD INDEX author_idx (author)");
         safe_update($table, "author='".doSlash($txp_user)."'", '1=1');
     }
 }

--- a/textpattern/update/_to_4.5.0.php
+++ b/textpattern/update/_to_4.5.0.php
@@ -54,7 +54,7 @@ foreach ($rs as $row) {
 }
 
 if (!$has_idx) {
-    safe_query('alter ignore table `'.PFX.'textpattern` add index url_title_idx(`url_title`)');
+    safe_query('alter ignore table `'.PFX.'textpattern` add index url_title_idx(`url_title`(250))');
 }
 
 // Remove is_default from txp_section table and make it a preference.

--- a/textpattern/update/_to_4.5.7.php
+++ b/textpattern/update/_to_4.5.7.php
@@ -32,7 +32,7 @@ safe_alter('txp_discuss', "MODIFY email VARCHAR(254) NOT NULL default ''");
 safe_alter('txp_log', "MODIFY ip VARCHAR(45) NOT NULL default ''");
 
 // Save sections correctly in articles.
-safe_alter('textpattern', "MODIFY Section VARCHAR(128) NOT NULL default ''");
+safe_alter('textpattern', "MODIFY Section VARCHAR(255) NOT NULL default ''");
 
 // Ensure all memory-mappable columns have defaults
 safe_alter('txp_form', "MODIFY `name` VARCHAR(64) NOT NULL default ''");

--- a/textpattern/update/_to_4.6.0.php
+++ b/textpattern/update/_to_4.6.0.php
@@ -127,3 +127,15 @@ if (safe_field('name', 'txp_prefs', "name = 'ping_textpattern_com'")) {
 if (!get_pref('default_publish_status')) {
     set_pref('default_publish_status', STATUS_LIVE, 'publish', PREF_CORE, 'defaultPublishStatus', 15, PREF_PRIVATE);
 }
+
+// Recreate indexes to allow future conversion to charset utf8mb4
+safe_alter('txp_discuss_ipban', "DROP PRIMARY KEY, ADD PRIMARY KEY (`ip`(250))");
+safe_alter('txp_discuss_nonce', "DROP PRIMARY KEY, ADD PRIMARY KEY (`nonce`(250))");
+safe_alter('txp_css', "DROP INDEX `name`, ADD UNIQUE `name` (`name`(250))");
+safe_alter('txp_file', "DROP INDEX `filename`, ADD UNIQUE `filename` (`filename`(250))");
+safe_alter('txp_form', "DROP PRIMARY KEY, ADD PRIMARY KEY (`name`(250))");
+safe_alter('txp_page', "DROP PRIMARY KEY, ADD PRIMARY KEY (`name`(250))");
+safe_alter('txp_section', "DROP PRIMARY KEY, ADD PRIMARY KEY (`name`(250))");
+safe_alter('txp_prefs', "DROP INDEX `prefs_idx`, ADD UNIQUE `prefs_idx` (`prefs_id`,`name`(185),`user_name`)");
+safe_alter('textpattern', "DROP INDEX `section_status_idx`, ADD INDEX `section_status_idx` (`Section`(249),`Status`)");
+safe_alter('textpattern', "DROP INDEX `url_title_idx`, ADD INDEX `url_title_idx` (`url_title`(250))");

--- a/textpattern/update/_to_4.6.0.php
+++ b/textpattern/update/_to_4.6.0.php
@@ -76,6 +76,7 @@ safe_update(
 
 // Usernames can be 64 characters long at most.
 safe_alter('txp_file', "MODIFY author VARCHAR(64) NOT NULL default ''");
+safe_alter('txp_link', "MODIFY author VARCHAR(64) NOT NULL default ''");
 safe_alter('txp_image', "MODIFY author VARCHAR(64) NOT NULL default ''");
 
 // Consistent name length limitations for presentation items.


### PR DESCRIPTION
The MySQL charset utf8 does now allow the full UTF-8 character set. It only allows characters of up to 3 bytes long. utf8mb4 allows the full range of UTF-8 characters (incl 4 byte chars).

This is also a good time to change the collation from generic_ci to unicode_ci. Although slightly slower, it does provide more accurate sorting according to unicode rules.

Wordpress and Drupal have already made these changes.