### PR TITLE
use fetch_form() in the search_input taghandler

### DIFF
--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -1565,7 +1565,7 @@ function search_input($atts)
     ), $atts));
 
     if ($form) {
-        $rs = fetch('form', 'txp_form', 'name', $form);
+        $rs = fetch_form($form);
 
         if ($rs) {
             return parse($rs);


### PR DESCRIPTION
Using fetch_form allows the form to be cached.