### PR TITLE
Make search_input behave more as expected.

### DIFF
--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -1564,9 +1564,9 @@ function search_input($atts)
         'match'   => 'exact',
     ), $atts));
 
-    if ($form) {
+    if ($form and !array_diff_key($atts, array('form' => true))) {
         $rs = fetch_form($form);
-
+        
         if ($rs) {
             return parse($rs);
         }

--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -1566,7 +1566,7 @@ function search_input($atts)
 
     if ($form and !array_diff_key($atts, array('form' => true))) {
         $rs = fetch_form($form);
-        
+
         if ($rs) {
             return parse($rs);
         }


### PR DESCRIPTION
search_input has a lot of attributes, but apart from 'form', none of them have any effect, unless you also set form to either an empty string or a non-existent form. That is too much magic for a user. This patch checks if there are any other attributes specified (besides form). If so, it assumes that you don't want to use the form.

This is one of the possible ways to fix issue #541