### PR TITLE
Admin-side SQL query reduction / optimisation

### DIFF
--- a/rpc/index.php
+++ b/rpc/index.php
@@ -77,7 +77,7 @@ require_once txpath.'/lib/txplib_misc.php';
 require_once txpath.'/lib/admin_config.php';
 require_once txpath.'/lib/IXRClass.php';
 
-if ($connected && safe_query("describe `".PFX."textpattern`")) {
+if ($connected && numRows(safe_query("show tables like '".PFX."textpattern'"))) {
     // TODO: where is dbversion used?
     $dbversion = safe_field('val', 'txp_prefs', "name = 'version'");
 

--- a/textpattern/include/txp_admin.php
+++ b/textpattern/include/txp_admin.php
@@ -382,7 +382,7 @@ function author_list($message = '')
 
         list($page, $offset, $numPages) = pager($total, $limit, $page);
 
-        $use_multi_edit = (has_privs('admin.edit') && (safe_count('txp_users', '1=1') > 1));
+        $use_multi_edit = (has_privs('admin.edit') && ($total > 1 or safe_count('txp_users', '1=1') > 1));
 
         echo author_search_form($crit, $search_method).'</div>';
 

--- a/textpattern/include/txp_admin.php
+++ b/textpattern/include/txp_admin.php
@@ -314,22 +314,22 @@ function author_list($message = '')
 
         if ($sort === '') {
             $sort = get_pref('admin_sort_column', 'name');
+        } else {
+            if (!in_array($sort, array('name', 'RealName', 'email', 'privs', 'last_login'))) {
+                $sort = 'name';
+            }
+
+            set_pref('admin_sort_column', $sort, 'admin', 2, '', 0, PREF_PRIVATE);
         }
 
         if ($dir === '') {
             $dir = get_pref('admin_sort_dir', 'asc');
-        }
-
-        $dir = ($dir == 'desc') ? 'desc' : 'asc';
-
-        if (!in_array($sort, array('name', 'RealName', 'email', 'privs', 'last_login'))) {
-            $sort = 'name';
+        } else {
+            $dir = ($dir == 'desc') ? 'desc' : 'asc';
+            set_pref('admin_sort_dir', $dir, 'admin', 2, '', 0, PREF_PRIVATE);
         }
 
         $sort_sql = $sort.' '.$dir;
-
-        set_pref('admin_sort_column', $sort, 'admin', 2, '', 0, PREF_PRIVATE);
-        set_pref('admin_sort_dir', $dir, 'admin', 2, '', 0, PREF_PRIVATE);
 
         $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 

--- a/textpattern/include/txp_discuss.php
+++ b/textpattern/include/txp_discuss.php
@@ -122,13 +122,20 @@ function discuss_list($message = '')
 
     if ($sort === '') {
         $sort = get_pref('discuss_sort_column', 'date');
+    } else {
+        if (!in_array($sort, array('id', 'ip', 'name', 'email', 'website', 'message', 'status', 'parent'))) {
+            $sort = 'date';
+        }
+
+        set_pref('discuss_sort_column', $sort, 'discuss', 2, '', 0, PREF_PRIVATE);
     }
 
     if ($dir === '') {
         $dir = get_pref('discuss_sort_dir', 'desc');
+    } else {
+        $dir = ($dir == 'asc') ? 'asc' : 'desc';
+        set_pref('discuss_sort_dir', $dir, 'discuss', 2, '', 0, PREF_PRIVATE);
     }
-
-    $dir = ($dir == 'asc') ? 'asc' : 'desc';
 
     switch ($sort) {
         case 'id':
@@ -164,9 +171,6 @@ function discuss_list($message = '')
     if ($sort != 'date') {
         $sort_sql .= ', txp_discuss.posted asc';
     }
-
-    set_pref('discuss_sort_column', $sort, 'discuss', 2, '', 0, PREF_PRIVATE);
-    set_pref('discuss_sort_dir', $dir, 'discuss', 2, '', 0, PREF_PRIVATE);
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 

--- a/textpattern/include/txp_file.php
+++ b/textpattern/include/txp_file.php
@@ -82,16 +82,19 @@ function file_list($message = '')
 
     if ($sort === '') {
         $sort = get_pref('file_sort_column', 'filename');
+    } else {
+        if (!in_array($sort, array('id', 'description', 'category', 'title', 'downloads', 'author'))) {
+            $sort = 'filename';
+        }
+
+        set_pref('file_sort_column', $sort, 'file', PREF_HIDDEN, '', 0, PREF_PRIVATE);
     }
 
     if ($dir === '') {
         $dir = get_pref('file_sort_dir', 'asc');
-    }
-
-    if ($dir === 'desc') {
-        $dir = 'desc';
     } else {
-        $dir = 'asc';
+        $dir = ($dir == 'asc') ? 'asc' : 'desc';
+        set_pref('file_sort_dir', $dir, 'file', PREF_HIDDEN, '', 0, PREF_PRIVATE);
     }
 
     echo
@@ -147,14 +150,7 @@ function file_list($message = '')
             break;
     }
 
-    set_pref('file_sort_column', $sort, 'file', PREF_HIDDEN, '', 0, PREF_PRIVATE);
-    set_pref('file_sort_dir', $dir, 'file', PREF_HIDDEN, '', 0, PREF_PRIVATE);
-
-    if ($dir == 'desc') {
-        $switch_dir = 'asc';
-    } else {
-        $switch_dir = 'desc';
-    }
+    $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
     $criteria = 1;
 

--- a/textpattern/include/txp_form.php
+++ b/textpattern/include/txp_form.php
@@ -114,7 +114,7 @@ function form_list($curname)
     $criteria .= callback_event('admin_criteria', 'form_list', 0, $criteria);
 
     $rs = safe_rows_start(
-        '*',
+        'name, type',
         'txp_form',
         "$criteria order by field(type, ".join(',', quote_list(array_keys($form_types))).") asc, name asc"
     );

--- a/textpattern/include/txp_image.php
+++ b/textpattern/include/txp_image.php
@@ -71,12 +71,20 @@ function image_list($message = '')
 
     if ($sort === '') {
         $sort = get_pref('image_sort_column', 'id');
+    } else {
+        if (!in_array($sort, array('name', 'thumbnail', 'category', 'date', 'author'))) {
+            $sort = 'id';
+        }
+
+        set_pref('image_sort_column', $sort, 'image', 2, '', 0, PREF_PRIVATE);
     }
 
     if ($dir === '') {
         $dir = get_pref('image_sort_dir', 'desc');
+    } else {
+        $dir = ($dir == 'asc') ? 'asc' : 'desc';
+        set_pref('image_sort_dir', $dir, 'image', 2, '', 0, PREF_PRIVATE);
     }
-    $dir = ($dir == 'asc') ? 'asc' : 'desc';
 
     echo hed(gTxt('tab_image'), 1, array('class' => 'txp-heading'));
     echo n.'<div id="'.$event.'_control" class="txp-control-panel">';
@@ -112,9 +120,6 @@ function image_list($message = '')
             $sort_sql = 'id '.$dir;
             break;
     }
-
-    set_pref('image_sort_column', $sort, 'image', 2, '', 0, PREF_PRIVATE);
-    set_pref('image_sort_dir', $dir, 'image', 2, '', 0, PREF_PRIVATE);
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 

--- a/textpattern/include/txp_image.php
+++ b/textpattern/include/txp_image.php
@@ -101,23 +101,23 @@ function image_list($message = '')
 
     switch ($sort) {
         case 'name':
-            $sort_sql = 'name '.$dir;
+            $sort_sql = 'txp_image.name '.$dir;
             break;
         case 'thumbnail':
-            $sort_sql = 'thumbnail '.$dir.', id asc';
+            $sort_sql = 'txp_image.thumbnail '.$dir.', txp_image.id asc';
             break;
         case 'category':
-            $sort_sql = 'category '.$dir.', id asc';
+            $sort_sql = 'txp_category.title '.$dir.', txp_image.id asc';
             break;
         case 'date':
-            $sort_sql = 'date '.$dir.', id asc';
+            $sort_sql = 'txp_image.date '.$dir.', txp_image.id asc';
             break;
         case 'author':
-            $sort_sql = 'author '.$dir.', id asc';
+            $sort_sql = 'txp_users.RealName '.$dir.', txp_image.id asc';
             break;
         default:
             $sort = 'id';
-            $sort_sql = 'id '.$dir;
+            $sort_sql = 'txp_image.id '.$dir;
             break;
     }
 
@@ -130,19 +130,19 @@ function image_list($message = '')
         $crit_escaped = $verbatim ? doSlash($m[1]) : doLike($crit);
         $critsql = $verbatim ?
             array(
-                'id'       => "ID in ('".join("','", do_list($crit_escaped))."')",
-                'name'     => "name = '$crit_escaped'",
-                'category' => "category = '$crit_escaped'",
-                'author'   => "author = '$crit_escaped'",
-                'alt'      => "alt = '$crit_escaped'",
-                'caption'  => "caption = '$crit_escaped'",
+                'id'       => "txp_image.ID in ('".join("','", do_list($crit_escaped))."')",
+                'name'     => "txp_image.name = '$crit_escaped'",
+                'category' => "txp_image.category = '$crit_escaped' or txp_category.title = '$crit_escaped'",
+                'author'   => "txp_image.author = '$crit_escaped' or txp_users.RealName = '$crit_escaped'",
+                'alt'      => "txp_image.alt = '$crit_escaped'",
+                'caption'  => "txp_image.caption = '$crit_escaped'",
             ) : array(
-                'id'       => "ID in ('".join("','", do_list($crit_escaped))."')",
-                'name'     => "name like '%$crit_escaped%'",
-                'category' => "category like '%$crit_escaped%'",
-                'author'   => "author like '%$crit_escaped%'",
-                'alt'      => "alt like '%$crit_escaped%'",
-                'caption'  => "caption like '%$crit_escaped%'",
+                'id'       => "txp_image.ID in ('".join("','", do_list($crit_escaped))."')",
+                'name'     => "txp_image.name like '%$crit_escaped%'",
+                'category' => "txp_image.category like '%$crit_escaped%'",
+                'author'   => "txp_image.author like '%$crit_escaped%' or txp_category.title like '%$crit_escaped%'",
+                'alt'      => "txp_image.alt like '%$crit_escaped%' or txp_users.RealName like '%$crit_escaped%'",
+                'caption'  => "txp_image.caption like '%$crit_escaped%'",
             );
 
         if (array_key_exists($search_method, $critsql)) {
@@ -159,7 +159,16 @@ function image_list($message = '')
 
     $criteria .= callback_event('admin_criteria', 'image_list', 0, $criteria);
 
-    $total = safe_count('txp_image', "$criteria");
+    $sql_from =
+        safe_pfx_j('txp_image')."
+        left join ".safe_pfx_j('txp_category')." on txp_category.name = txp_image.category and txp_category.type = 'image'
+        left join ".safe_pfx_j('txp_users')." on txp_users.name = txp_image.author";
+
+    if ($criteria === 1) {
+        $total = getCount('txp_image', $criteria);
+    } else {
+        $total = getThing('select count(*) from '.$sql_from.' where '.$criteria);
+    }
 
     if ($total < 1) {
         if ($criteria != 1) {
@@ -178,9 +187,25 @@ function image_list($message = '')
 
     echo image_search_form($crit, $search_method);
 
-    $rs = safe_rows_start('*, unix_timestamp(date) as uDate', 'txp_image',
-        "$criteria order by $sort_sql limit $offset, $limit
-    ");
+    $rs = safe_query(
+        "select
+            txp_image.id,
+            txp_image.name,
+            txp_image.category,
+            txp_image.ext,
+            txp_image.w,
+            txp_image.h,
+            txp_image.alt,
+            txp_image.caption,
+            unix_timestamp(txp_image.date) as uDate,
+            txp_image.author,
+            txp_image.thumbnail,
+            txp_image.thumb_w,
+            txp_image.thumb_h,
+            txp_users.RealName as realname,
+            txp_category.Title as category_title
+        from $sql_from where $criteria order by $sort_sql limit $offset, $limit"
+    );
 
     echo pluggable_ui('image_ui', 'extend_controls', '', $rs);
     echo '</div>'; // End txp-control-panel.
@@ -285,9 +310,9 @@ function image_list($message = '')
             $validator->setConstraints(array(new CategoryConstraint($category, array('type' => 'image'))));
             $vc = $validator->validate() ? '' : ' error';
 
-            $category = ($category)
-                ? span($category, array('title' => fetch_category_title($category, 'image')))
-                : '';
+            if ($category) {
+                $category = span(txpspecialchars($category_title), array('title' => $category));
+            }
 
             $can_edit = has_privs('image.edit') || ($author === $txp_user && has_privs('image.edit.own'));
 
@@ -319,7 +344,7 @@ function image_list($message = '')
                 ).
                 (
                     $show_authors
-                    ? td(span(txpspecialchars($author), array('title' => get_author_name($author))), '', 'txp-list-col-author name')
+                    ? td(span(txpspecialchars($realname), array('title' => $author)), '', 'txp-list-col-author name')
                     : ''
                 )
             );

--- a/textpattern/include/txp_link.php
+++ b/textpattern/include/txp_link.php
@@ -142,7 +142,7 @@ function link_list($message = '')
 
     $sql_from =
         safe_pfx_j('txp_link')."
-        left join ".safe_pfx_j('txp_category')." on txp_category.name = txp_link.category and txp_category.type = 'file'
+        left join ".safe_pfx_j('txp_category')." on txp_category.name = txp_link.category and txp_category.type = 'link'
         left join ".safe_pfx_j('txp_users')." on txp_users.name = txp_link.author";
 
     if ($criteria === 1) {

--- a/textpattern/include/txp_link.php
+++ b/textpattern/include/txp_link.php
@@ -63,12 +63,20 @@ function link_list($message = '')
 
     if ($sort === '') {
         $sort = get_pref('link_sort_column', 'name');
+    } else {
+        if (!in_array($sort, array('id', 'description', 'url', 'category', 'date', 'author'))) {
+            $sort = 'name';
+        }
+
+        set_pref('link_sort_column', $sort, 'link', 2, '', 0, PREF_PRIVATE);
     }
 
     if ($dir === '') {
         $dir = get_pref('link_sort_dir', 'asc');
+    } else {
+        $dir = ($dir == 'desc') ? 'desc' : 'asc';
+        set_pref('link_sort_dir', $dir, 'link', 2, '', 0, PREF_PRIVATE);
     }
-    $dir = ($dir == 'desc') ? 'desc' : 'asc';
 
     switch ($sort) {
         case 'id':
@@ -94,9 +102,6 @@ function link_list($message = '')
             $sort_sql = 'linksort '.$dir.', id asc';
             break;
     }
-
-    set_pref('link_sort_column', $sort, 'link', 2, '', 0, PREF_PRIVATE);
-    set_pref('link_sort_dir', $dir, 'link', 2, '', 0, PREF_PRIVATE);
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 

--- a/textpattern/include/txp_link.php
+++ b/textpattern/include/txp_link.php
@@ -80,26 +80,26 @@ function link_list($message = '')
 
     switch ($sort) {
         case 'id':
-            $sort_sql = 'id '.$dir;
+            $sort_sql = 'txp_link.id '.$dir;
             break;
         case 'description':
-            $sort_sql = 'description '.$dir.', id asc';
+            $sort_sql = 'txp_link.description '.$dir.', txp_link.id asc';
             break;
         case 'url':
-            $sort_sql = 'url '.$dir.', id asc';
+            $sort_sql = 'txp_link.url '.$dir.', txp_link.id asc';
             break;
         case 'category':
-            $sort_sql = 'category '.$dir.', id asc';
+            $sort_sql = 'txp_category.title '.$dir.', txp_link.id asc';
             break;
         case 'date':
-            $sort_sql = 'date '.$dir.', id asc';
+            $sort_sql = 'txp_link.date '.$dir.', txp_link.id asc';
             break;
         case 'author':
-            $sort_sql = 'author '.$dir.', id asc';
+            $sort_sql = 'txp_users.RealName '.$dir.', txp_link.id asc';
             break;
         default:
             $sort = 'name';
-            $sort_sql = 'linksort '.$dir.', id asc';
+            $sort_sql = 'txp_link.linksort '.$dir.', txp_link.id asc';
             break;
     }
 
@@ -176,7 +176,6 @@ function link_list($message = '')
 
     echo link_search_form($crit, $search_method).'</div>';
 
-    $rs = safe_rows_start('*, unix_timestamp(date) as uDate', 'txp_link', "$criteria order by $sort_sql limit $offset, $limit");
     $rs = safe_query(
         "select
             txp_link.id,

--- a/textpattern/include/txp_list.php
+++ b/textpattern/include/txp_list.php
@@ -85,13 +85,20 @@ function list_list($message = '', $post = '')
 
     if ($sort === '') {
         $sort = get_pref('article_sort_column', 'posted');
+    } else {
+        if (!in_array($sort, array('id', 'title', 'expires', 'section', 'category1', 'category2', 'status', 'author', 'comments', 'lastmod'))) {
+            $sort = 'posted';
+        }
+
+        set_pref('article_sort_column', $sort, 'list', 2, '', 0, PREF_PRIVATE);
     }
 
     if ($dir === '') {
         $dir = get_pref('article_sort_dir', 'desc');
+    } else {
+        $dir = ($dir == 'asc') ? 'asc' : 'desc';
+        set_pref('article_sort_dir', $dir, 'list', 2, '', 0, PREF_PRIVATE);
     }
-
-    $dir = ($dir == 'asc') ? 'asc' : 'desc';
 
     $sesutats = array_flip($statuses);
 
@@ -131,9 +138,6 @@ function list_list($message = '', $post = '')
             $sort_sql = 'textpattern.Posted '.$dir;
             break;
     }
-
-    set_pref('article_sort_column', $sort, 'list', 2, '', 0, PREF_PRIVATE);
-    set_pref('article_sort_dir', $dir, 'list', 2, '', 0, PREF_PRIVATE);
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 

--- a/textpattern/include/txp_log.php
+++ b/textpattern/include/txp_log.php
@@ -74,13 +74,20 @@ function log_list($message = '')
 
     if ($sort === '') {
         $sort = get_pref('log_sort_column', 'time');
+    } else {
+        if (!in_array($sort, array('ip', 'host', 'page', 'refer', 'method', 'status'))) {
+            $sort = 'time';
+        }
+
+        set_pref('log_sort_column', $sort, 'log', 2, '', 0, PREF_PRIVATE);
     }
 
     if ($dir === '') {
         $dir = get_pref('log_sort_dir', 'desc');
+    } else {
+        $dir = ($dir == 'asc') ? 'asc' : 'desc';
+        set_pref('log_sort_dir', $dir, 'log', 2, '', 0, PREF_PRIVATE);
     }
-
-    $dir = ($dir == 'asc') ? 'asc' : 'desc';
 
     $expire_logs_after = assert_int($expire_logs_after);
 
@@ -110,9 +117,6 @@ function log_list($message = '')
             $sort_sql = 'time '.$dir;
             break;
     }
-
-    set_pref('log_sort_column', $sort, 'log', 2, '', 0, PREF_PRIVATE);
-    set_pref('log_sort_dir', $dir, 'log', 2, '', 0, PREF_PRIVATE);
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 

--- a/textpattern/include/txp_plugin.php
+++ b/textpattern/include/txp_plugin.php
@@ -74,22 +74,22 @@ function plugin_list($message = '')
 
     if ($sort === '') {
         $sort = get_pref('plugin_sort_column', 'name');
+    } else {
+        if (!in_array($sort, array('name', 'status', 'author', 'version', 'modified', 'load_order'))) {
+            $sort = 'name';
+        }
+
+        set_pref('plugin_sort_column', $sort, 'plugin', 2, '', 0, PREF_PRIVATE);
     }
 
     if ($dir === '') {
         $dir = get_pref('plugin_sort_dir', 'asc');
-    }
-
-    $dir = ($dir == 'desc') ? 'desc' : 'asc';
-
-    if (!in_array($sort, array('name', 'status', 'author', 'version', 'modified', 'load_order'))) {
-        $sort = 'name';
+    } else {
+        $dir = ($dir == 'desc') ? 'desc' : 'asc';
+        set_pref('plugin_sort_dir', $dir, 'plugin', 2, '', 0, PREF_PRIVATE);
     }
 
     $sort_sql = $sort.' '.$dir;
-
-    set_pref('plugin_sort_column', $sort, 'plugin', 2, '', 0, PREF_PRIVATE);
-    set_pref('plugin_sort_dir', $dir, 'plugin', 2, '', 0, PREF_PRIVATE);
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 

--- a/textpattern/include/txp_section.php
+++ b/textpattern/include/txp_section.php
@@ -80,13 +80,21 @@ function sec_section_list($message = '')
     )));
 
     if ($sort === '') {
-        $sort = get_pref('section_sort_column', 'time');
+        $sort = get_pref('section_sort_column', 'name');
+    } else {
+        if (!in_array($sort, array('title', 'page', 'css', 'in_rss', 'on_frontpage', 'searchable', 'article_count'))) {
+            $sort = 'name';
+        }
+
+        set_pref('section_sort_column', $sort, 'section', 2, '', 0, PREF_PRIVATE);
     }
 
     if ($dir === '') {
         $dir = get_pref('section_sort_dir', 'desc');
+    } else {
+        $dir = ($dir == 'asc') ? 'asc' : 'desc';
+        set_pref('section_sort_dir', $dir, 'section', 2, '', 0, PREF_PRIVATE);
     }
-    $dir = ($dir == 'asc') ? 'asc' : 'desc';
 
     switch ($sort) {
         case 'title':
@@ -114,9 +122,6 @@ function sec_section_list($message = '')
             $sort_sql = 'name '.$dir;
             break;
     }
-
-    set_pref('section_sort_column', $sort, 'section', 2, '', 0, PREF_PRIVATE);
-    set_pref('section_sort_dir', $dir, 'section', 2, '', 0, PREF_PRIVATE);
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 

--- a/textpattern/index.php
+++ b/textpattern/index.php
@@ -103,7 +103,7 @@ trace_add('[PHP Include end]');
 
 set_error_handler('adminErrorHandler', error_reporting());
 
-if ($connected && safe_query("describe `".PFX."textpattern`")) {
+if ($connected && numRows(safe_query("show tables like '".PFX."textpattern'"))) {
     // Global site preferences.
     $prefs = get_prefs();
     extract($prefs);

--- a/textpattern/index.php
+++ b/textpattern/index.php
@@ -158,8 +158,8 @@ if ($connected && numRows(safe_query("show tables like '".PFX."textpattern'"))) 
     include txpath.'/include/txp_auth.php';
     doAuth();
 
-    // Once more for global plus private preferences.
-    $prefs = get_prefs();
+    // Private preferences.
+    $prefs = get_prefs($txp_user);
     extract($prefs);
 
     /**

--- a/textpattern/index.php
+++ b/textpattern/index.php
@@ -158,8 +158,8 @@ if ($connected && numRows(safe_query("show tables like '".PFX."textpattern'"))) 
     include txpath.'/include/txp_auth.php';
     doAuth();
 
-    // Private preferences.
-    $prefs = get_prefs($txp_user);
+    // Add private preferences.
+    $prefs = array_merge(get_prefs($txp_user), $prefs);
     extract($prefs);
 
     /**

--- a/textpattern/index.php
+++ b/textpattern/index.php
@@ -104,11 +104,11 @@ trace_add('[PHP Include end]');
 set_error_handler('adminErrorHandler', error_reporting());
 
 if ($connected && safe_query("describe `".PFX."textpattern`")) {
-    $dbversion = safe_field('val', 'txp_prefs', "name = 'version'");
-
     // Global site preferences.
     $prefs = get_prefs();
     extract($prefs);
+
+    $dbversion = $version;
 
     if (empty($siteurl)) {
         $httphost = preg_replace('/[^-_a-zA-Z0-9.:]/', '', $_SERVER['HTTP_HOST']);

--- a/textpattern/lib/txplib_head.php
+++ b/textpattern/lib/txplib_head.php
@@ -48,7 +48,7 @@
 
 function pagetop($pagetitle, $message = '')
 {
-    global $siteurl, $sitename, $txp_user, $event, $step, $app_mode, $theme, $privs;
+    global $siteurl, $sitename, $txp_user, $event, $step, $app_mode, $theme;
 
     if ($app_mode == 'async') {
         return;
@@ -57,8 +57,6 @@ function pagetop($pagetitle, $message = '')
     $area = gps('area');
     $event = (!$event) ? 'article' : $event;
     $bm = gps('bm');
-
-    $privs = safe_field("privs", "txp_users", "name = '".doSlash($txp_user)."'");
 
     $areas = areas();
     $area = false;

--- a/textpattern/lib/txplib_head.php
+++ b/textpattern/lib/txplib_head.php
@@ -253,7 +253,7 @@ function tabsort($area, $event)
 
 function areas()
 {
-    global $privs, $plugin_areas;
+    global $plugin_areas;
 
     $areas['start'] = array(
     );

--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -4555,24 +4555,10 @@ function handle_lastmod($unix_ts = null, $exit = true)
  * @see     get_pref()
  */
 
-function get_prefs()
+function get_prefs($user = '')
 {
-    global $txp_user;
     $out = array();
-
-    // Get current user's private prefs.
-    if ($txp_user) {
-        $r = safe_rows_start('name, val', 'txp_prefs', 'prefs_id=1 AND user_name=\''.doSlash($txp_user).'\'');
-
-        if ($r) {
-            while ($a = nextRow($r)) {
-                $out[$a['name']] = $a['val'];
-            }
-        }
-    }
-
-    // Get global prefs, eventually override equally named user prefs.
-    $r = safe_rows_start('name, val', 'txp_prefs', 'prefs_id=1 AND user_name=\'\'');
+    $r = safe_rows_start('name, val', 'txp_prefs', 'prefs_id=1 AND user_name=\''.doSlash($txp_user).'\'');
 
     if ($r) {
         while ($a = nextRow($r)) {

--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -4558,7 +4558,7 @@ function handle_lastmod($unix_ts = null, $exit = true)
 function get_prefs($user = '')
 {
     $out = array();
-    $r = safe_rows_start('name, val', 'txp_prefs', 'prefs_id=1 AND user_name=\''.doSlash($txp_user).'\'');
+    $r = safe_rows_start('name, val', 'txp_prefs', 'prefs_id=1 AND user_name=\''.doSlash($user).'\'');
 
     if ($r) {
         while ($a = nextRow($r)) {

--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -4541,14 +4541,16 @@ function handle_lastmod($unix_ts = null, $exit = true)
 }
 
 /**
- * Gets all preferences as an array.
+ * Gets preferences as an array.
  *
- * Returns all preference values from the database as an array. Shouldn't be used to
+ * Returns preference values from the database as an array. Shouldn't be used to
  * retrieve selected preferences, see get_pref() instead.
  *
- * If run on an authenticated admin page, the results include current user's
- * private preferences. Any global preference overrides equally named user prefs.
+ * By default only the global preferences are returned. 
+ * If the optional user name parameter is supplied, the private preferences
+ * for that user are returned.
  *
+ * @param   string $user User name.
  * @return  array
  * @package Pref
  * @access  private

--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -3647,8 +3647,14 @@ function get_author_email($name)
 
 function has_single_author($table, $col = 'author')
 {
-    return (safe_field('COUNT(name)', 'txp_users', '1=1') <= 1) &&
-        (safe_field('COUNT(DISTINCT('.doSlash($col).'))', doSlash($table), '1=1') <= 1);
+    static $cache = array();
+
+    if (!isset($cache[$table][$col])) {
+        $cache[$table][$col] = (safe_field('COUNT(name)', 'txp_users', '1=1') <= 1) &&
+            (safe_field('COUNT(DISTINCT('.doSlash($col).'))', doSlash($table), '1=1') <= 1);
+    }
+
+    return $cache[$table][$col];
 }
 
 /**


### PR DESCRIPTION
This series of commits reduces the amount of SQL queries on the admin side:
* remove unused privs query in pagetop function (saves 1 query)
* remove unnecessary query to fetch $dbversion (saves 1 query)
* don't fetch global prefs twice (saves 1 query). Does involve a change in the get_prefs function.
* don't store private user sorting prefs if the user didn't change them (saves 4 queries)
* don't count users twice on user list page (saves 1 query typically)
* cache has_single_author results (saves 1 or 2 queries)
* use joins on the links and images pages to avoid separate queries for each category / author name (saves up to 2 queries per link / image)

On most admin-side pages this results in 8 less SQL queries.

And a few optimisations:
* use 'show tables' instead of 'describe table' to check if textpattern table exists (twice as fast)
* don't load form contents while displaying a list of forms (name, type are sufficient)

This fixes issue #310 (and more).
