### PR TITLE
Fix regression caused by #570 (SQL coding style fixes)

### DIFF
--- a/textpattern/include/txp_admin.php
+++ b/textpattern/include/txp_admin.php
@@ -323,16 +323,15 @@ function author_list($message = '')
         }
 
         if ($dir === '') {
-            $dir = get_pref('admin_sort_dir', 'ASC');
+            $dir = get_pref('admin_sort_dir', 'asc');
         } else {
-            $dir = ($dir == 'DESC') ? "DESC" : "ASC";
+            $dir = ($dir == 'desc') ? "desc" : "asc";
             set_pref('admin_sort_dir', $dir, 'admin', 2, '', 0, PREF_PRIVATE);
         }
 
         $sort_sql = $sort.' '.$dir;
 
-        $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
-        $dir = strtolower($dir);
+        $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
         $criteria = 1;
 

--- a/textpattern/include/txp_admin.php
+++ b/textpattern/include/txp_admin.php
@@ -332,6 +332,7 @@ function author_list($message = '')
         $sort_sql = $sort.' '.$dir;
 
         $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
+        $dir = strtolower($dir);
 
         $criteria = 1;
 

--- a/textpattern/include/txp_discuss.php
+++ b/textpattern/include/txp_discuss.php
@@ -141,9 +141,9 @@ function discuss_list($message = '')
     }
 
     if ($dir === '') {
-        $dir = get_pref('discuss_sort_dir', 'DESC');
+        $dir = get_pref('discuss_sort_dir', 'desc');
     } else {
-        $dir = ($dir == 'ASC') ? "ASC" : "DESC";
+        $dir = ($dir == 'asc') ? "asc" : "desc";
         set_pref('discuss_sort_dir', $dir, 'discuss', 2, '', 0, PREF_PRIVATE);
     }
 
@@ -182,8 +182,7 @@ function discuss_list($message = '')
         $sort_sql .= ", txp_discuss.posted ASC";
     }
 
-    $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
-    $dir = strtolower($dir);
+    $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
     $criteria = 1;
 

--- a/textpattern/include/txp_discuss.php
+++ b/textpattern/include/txp_discuss.php
@@ -183,6 +183,7 @@ function discuss_list($message = '')
     }
 
     $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
+    $dir = strtolower($dir);
 
     $criteria = 1;
 

--- a/textpattern/include/txp_file.php
+++ b/textpattern/include/txp_file.php
@@ -165,6 +165,7 @@ function file_list($message = '')
     }
 
     $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
+    $dir = strtolower($dir);
 
     $criteria = 1;
 

--- a/textpattern/include/txp_file.php
+++ b/textpattern/include/txp_file.php
@@ -105,9 +105,9 @@ function file_list($message = '')
     }
 
     if ($dir === '') {
-        $dir = get_pref('file_sort_dir', 'ASC');
+        $dir = get_pref('file_sort_dir', 'asc');
     } else {
-        $dir = ($dir == 'ASC') ? "ASC" : "DESC";
+        $dir = ($dir == 'asc') ? "asc" : "desc";
         set_pref('file_sort_dir', $dir, 'file', PREF_HIDDEN, '', 0, PREF_PRIVATE);
     }
 
@@ -164,8 +164,7 @@ function file_list($message = '')
             break;
     }
 
-    $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
-    $dir = strtolower($dir);
+    $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
     $criteria = 1;
 

--- a/textpattern/include/txp_image.php
+++ b/textpattern/include/txp_image.php
@@ -135,6 +135,7 @@ function image_list($message = '')
     }
 
     $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
+    $dir = strtolower($dir);
 
     $criteria = 1;
 

--- a/textpattern/include/txp_image.php
+++ b/textpattern/include/txp_image.php
@@ -93,9 +93,9 @@ function image_list($message = '')
     }
 
     if ($dir === '') {
-        $dir = get_pref('image_sort_dir', 'DESC');
+        $dir = get_pref('image_sort_dir', 'desc');
     } else {
-        $dir = ($dir == 'ASC') ? "ASC" : "DESC";
+        $dir = ($dir == 'asc') ? "asc" : "desc";
         set_pref('image_sort_dir', $dir, 'image', 2, '', 0, PREF_PRIVATE);
     }
 
@@ -134,8 +134,7 @@ function image_list($message = '')
             break;
     }
 
-    $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
-    $dir = strtolower($dir);
+    $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
     $criteria = 1;
 

--- a/textpattern/include/txp_link.php
+++ b/textpattern/include/txp_link.php
@@ -85,9 +85,9 @@ function link_list($message = '')
     }
 
     if ($dir === '') {
-        $dir = get_pref('link_sort_dir', 'ASC');
+        $dir = get_pref('link_sort_dir', 'asc');
     } else {
-        $dir = ($dir == 'DESC') ? "DESC" : "ASC";
+        $dir = ($dir == 'desc') ? "desc" : "asc";
         set_pref('link_sort_dir', $dir, 'link', 2, '', 0, PREF_PRIVATE);
     }
 
@@ -116,8 +116,7 @@ function link_list($message = '')
             break;
     }
 
-    $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
-    $dir = strtolower($dir);
+    $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
     $criteria = 1;
 

--- a/textpattern/include/txp_link.php
+++ b/textpattern/include/txp_link.php
@@ -117,6 +117,7 @@ function link_list($message = '')
     }
 
     $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
+    $dir = strtolower($dir);
 
     $criteria = 1;
 

--- a/textpattern/include/txp_list.php
+++ b/textpattern/include/txp_list.php
@@ -144,6 +144,7 @@ function list_list($message = '', $post = '')
     }
 
     $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
+    $dir = strtolower($dir);
 
     $criteria = 1;
 

--- a/textpattern/include/txp_list.php
+++ b/textpattern/include/txp_list.php
@@ -98,9 +98,9 @@ function list_list($message = '', $post = '')
     }
 
     if ($dir === '') {
-        $dir = get_pref('article_sort_dir', 'DESC');
+        $dir = get_pref('article_sort_dir', 'desc');
     } else {
-        $dir = ($dir == 'ASC') ? "ASC" : "DESC";
+        $dir = ($dir == 'asc') ? "asc" : "desc";
         set_pref('article_sort_dir', $dir, 'list', 2, '', 0, PREF_PRIVATE);
     }
 
@@ -143,8 +143,7 @@ function list_list($message = '', $post = '')
             break;
     }
 
-    $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
-    $dir = strtolower($dir);
+    $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
     $criteria = 1;
 

--- a/textpattern/include/txp_log.php
+++ b/textpattern/include/txp_log.php
@@ -119,6 +119,7 @@ function log_list($message = '')
     }
 
     $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
+    $dir = strtolower($dir);
 
     $criteria = 1;
 

--- a/textpattern/include/txp_log.php
+++ b/textpattern/include/txp_log.php
@@ -83,9 +83,9 @@ function log_list($message = '')
     }
 
     if ($dir === '') {
-        $dir = get_pref('log_sort_dir', 'DESC');
+        $dir = get_pref('log_sort_dir', 'desc');
     } else {
-        $dir = ($dir == 'ASC') ? "ASC" : "DESC";
+        $dir = ($dir == 'asc') ? "asc" : "desc";
         set_pref('log_sort_dir', $dir, 'log', 2, '', 0, PREF_PRIVATE);
     }
 
@@ -118,8 +118,7 @@ function log_list($message = '')
             break;
     }
 
-    $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
-    $dir = strtolower($dir);
+    $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
     $criteria = 1;
 

--- a/textpattern/include/txp_plugin.php
+++ b/textpattern/include/txp_plugin.php
@@ -92,6 +92,7 @@ function plugin_list($message = '')
     $sort_sql = "$sort $dir";
 
     $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
+    $dir = strtolower($dir);
 
     $rs = safe_rows_start(
         "name, status, author, author_uri, version, description, length(help) AS help, ABS(STRCMP(MD5(code), code_md5)) AS modified, load_order, flags",

--- a/textpattern/include/txp_plugin.php
+++ b/textpattern/include/txp_plugin.php
@@ -83,16 +83,15 @@ function plugin_list($message = '')
     }
 
     if ($dir === '') {
-        $dir = get_pref('plugin_sort_dir', 'ASC');
+        $dir = get_pref('plugin_sort_dir', 'asc');
     } else {
-        $dir = ($dir == 'DESC') ? "DESC" : "ASC";
+        $dir = ($dir == 'desc') ? "desc" : "asc";
         set_pref('plugin_sort_dir', $dir, 'plugin', 2, '', 0, PREF_PRIVATE);
     }
 
     $sort_sql = "$sort $dir";
 
-    $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
-    $dir = strtolower($dir);
+    $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
     $rs = safe_rows_start(
         "name, status, author, author_uri, version, description, length(help) AS help, ABS(STRCMP(MD5(code), code_md5)) AS modified, load_order, flags",

--- a/textpattern/include/txp_section.php
+++ b/textpattern/include/txp_section.php
@@ -124,6 +124,7 @@ function sec_section_list($message = '')
     }
 
     $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
+    $dir = strtolower($dir);
 
     $criteria = 1;
 

--- a/textpattern/include/txp_section.php
+++ b/textpattern/include/txp_section.php
@@ -90,9 +90,9 @@ function sec_section_list($message = '')
     }
 
     if ($dir === '') {
-        $dir = get_pref('section_sort_dir', 'DESC');
+        $dir = get_pref('section_sort_dir', 'desc');
     } else {
-        $dir = ($dir == 'ASC') ? "ASC" : "DESC";
+        $dir = ($dir == 'asc') ? "asc" : "desc";
         set_pref('section_sort_dir', $dir, 'section', 2, '', 0, PREF_PRIVATE);
     }
 
@@ -123,8 +123,7 @@ function sec_section_list($message = '')
             break;
     }
 
-    $switch_dir = ($dir == 'DESC') ? 'ASC' : 'DESC';
-    $dir = strtolower($dir);
+    $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
     $criteria = 1;
 

--- a/textpattern/publish/atom.php
+++ b/textpattern/publish/atom.php
@@ -159,7 +159,7 @@ function atom()
         $limit = ($limit) ? $limit : $rss_how_many;
         $limit = intval(min($limit, max(100, $rss_how_many)));
 
-        $frs = safe_column("name", 'txp_section,' "in_rss != '1'");
+        $frs = safe_column("name", 'txp_section', "in_rss != '1'");
 
         $query = array();
 


### PR DESCRIPTION
I could fix it either by lowercasing $dir or by making an exception to the rule of having uppercase SQL keywords. The latter was preferable here because the change in case also affected the contents of a pref, causing a potential reversal of stored sort direction on upgrades.