### PR TITLE
Parser optimization and removal of ancient code

### DIFF
--- a/textpattern/lib/txplib_publish.php
+++ b/textpattern/lib/txplib_publish.php
@@ -458,23 +458,16 @@ function processTags($tag, $atts, $thing = null)
         $registry = Txp::get('\Textpattern\Tag\Registry');
     }
 
-    if ($registry->isRegistered($tag)) {
-        $out = $registry->process($tag, splat($atts), $thing);
-    }
+    $out = $registry->process($tag, splat($atts), $thing);
 
-    // Deprecated in 4.6.0.
-    elseif (maybe_tag($tag)) {
-        $out = $tag(splat($atts), $thing);
-        trigger_error(gTxt('unregistered_tag'), E_USER_NOTICE);
-    }
-
-    // Deprecated, remove in crockery.
-    elseif (isset($GLOBALS['pretext'][$tag])) {
-        $out = txpspecialchars($pretext[$tag]);
-        trigger_error(gTxt('deprecated_tag'), E_USER_NOTICE);
-    } else {
-        $out = '';
-        trigger_error(gTxt('unknown_tag'), E_USER_WARNING);
+    if ($out === false) {
+        if (maybe_tag($tag)) { // Deprecated in 4.6.0.
+            trigger_error(gTxt('unregistered_tag'), E_USER_NOTICE);
+            $out = $registry->register($tag)->process($tag, splat($atts), $thing);
+        } else {
+            trigger_error(gTxt('unknown_tag'), E_USER_WARNING);
+            $out = '';
+        }
     }
 
     if ($production_status !== 'live') {

--- a/textpattern/vendors/Textpattern/Tag/Registry.php
+++ b/textpattern/vendors/Textpattern/Tag/Registry.php
@@ -54,6 +54,7 @@ class Registry implements \Textpattern\Container\ReusableInterface
 
     public function register($callback, $tag = null)
     {
+        // is_callable only checks syntax here to avoid autoloading
         if (is_callable($callback, true)) {
             if ($tag === null && is_string($callback)) {
                 $tag = $callback;
@@ -73,13 +74,15 @@ class Registry implements \Textpattern\Container\ReusableInterface
      * @param  string      $tag   The tag
      * @param  array       $atts  An array of Attributes
      * @param  string|null $thing The contained statement
-     * @return string|null The tag's results
+     * @return string|bool The tag's results (string) or FALSE on unknown tags
      */
 
     public function process($tag, array $atts = null, $thing = null)
     {
         if ($this->isRegistered($tag)) {
-            return call_user_func($this->tags[$tag], (array)$atts, $thing);
+            return (string) call_user_func($this->tags[$tag], (array)$atts, $thing);
+        } else {
+            return false;
         }
     }
 


### PR DESCRIPTION
* Let $registry->processTags() return false if the tag is not registered or not callable (and a string otherwise). This makes it possible to avoid checking twice if a tag is registered, which makes parsing slightly faster.
* Clarify why doing is_callable during tag registering isn't enough and why we only do a syntax check there. This had me puzzled for a while.
* During processing, if we encounter an unregistered tag and it does appear to be an actual tag, register that tag and then process it again. It's enough to get one "unregistered tag" warning for each tag (if a tag occurs more than once).
* Remove some ancient code that has long been deprecated. No point in deprecating if the code never gets removed.