### PR TITLE
No zero dates in SQL. Category name 64 chars. Re-create txp_token

### DIFF
--- a/textpattern/lib/constants.php
+++ b/textpattern/lib/constants.php
@@ -183,7 +183,7 @@ if (!defined('REGEXP_UTF8')) {
  * @package DB
  */
 
-define('NULLDATETIME', '\'0000-00-00 00:00:00\'');
+define('NULLDATETIME', 'NULL');
 
 /**
  * Permlink URL mode.

--- a/textpattern/setup/txpsql.php
+++ b/textpattern/setup/txpsql.php
@@ -108,10 +108,10 @@ $create_sql = array();
 
 $create_sql[] = "CREATE TABLE `".PFX."textpattern` (
     ID              INT          NOT NULL AUTO_INCREMENT,
-    Posted          DATETIME     NOT NULL DEFAULT '0000-00-00 00:00:00',
-    Expires         DATETIME     NOT NULL DEFAULT '0000-00-00 00:00:00',
+    Posted          DATETIME     NOT NULL,
+    Expires         DATETIME     NOT NULL,
     AuthorID        VARCHAR(64)  NOT NULL DEFAULT '',
-    LastMod         DATETIME     NOT NULL DEFAULT '0000-00-00 00:00:00',
+    LastMod         DATETIME     NOT NULL,
     LastModID       VARCHAR(64)  NOT NULL DEFAULT '',
     Title           VARCHAR(255) NOT NULL DEFAULT '',
     Title_html      VARCHAR(255) NOT NULL DEFAULT '',
@@ -120,8 +120,8 @@ $create_sql[] = "CREATE TABLE `".PFX."textpattern` (
     Excerpt         TEXT         NOT NULL,
     Excerpt_html    MEDIUMTEXT   NOT NULL,
     Image           VARCHAR(255) NOT NULL DEFAULT '',
-    Category1       VARCHAR(128) NOT NULL DEFAULT '',
-    Category2       VARCHAR(128) NOT NULL DEFAULT '',
+    Category1       VARCHAR(64)  NOT NULL DEFAULT '',
+    Category2       VARCHAR(64)  NOT NULL DEFAULT '',
     Annotate        INT          NOT NULL DEFAULT '0',
     AnnotateInvite  VARCHAR(255) NOT NULL DEFAULT '',
     comments_count  INT          NOT NULL DEFAULT '0',
@@ -144,7 +144,7 @@ $create_sql[] = "CREATE TABLE `".PFX."textpattern` (
     custom_9        VARCHAR(255) NOT NULL DEFAULT '',
     custom_10       VARCHAR(255) NOT NULL DEFAULT '',
     uid             VARCHAR(32)  NOT NULL DEFAULT '',
-    feed_time       DATE         NOT NULL DEFAULT '0000-00-00',
+    feed_time       DATE         NOT NULL DEFAULT,
 
     PRIMARY KEY                 (ID),
     INDEX    categories_idx     (Category1(10), Category2(10)),
@@ -167,7 +167,7 @@ $article['body_html']    = $textile->textileThis($article['body']);
 $article['excerpt_html'] = $textile->textileThis($article['excerpt']);
 $article = doSlash($article);
 
-$create_sql[] = "INSERT INTO `".PFX."textpattern` VALUES (1, NOW(), '0000-00-00 00:00:00', '".doSlash($_SESSION['name'])."', NOW(), '', 'Welcome to your site', '', '".$article['body']."', '".$article['body_html']."', '".$article['excerpt']."', '".$article['excerpt_html']."', '', 'hope-for-the-future', 'meaningful-labor', 1, '".$setup_comment_invite."', 1, 4, '1', '1', 'articles', '', '', '', 'welcome-to-your-site', '', '', '', '', '', '', '', '', '', '', '".md5(uniqid(rand(), true))."', NOW())";
+$create_sql[] = "INSERT INTO `".PFX."textpattern` VALUES (1, NOW(), NULL, '".doSlash($_SESSION['name'])."', NOW(), '', 'Welcome to your site', '', '".$article['body']."', '".$article['body_html']."', '".$article['excerpt']."', '".$article['excerpt_html']."', '', 'hope-for-the-future', 'meaningful-labor', 1, '".$setup_comment_invite."', 1, 4, '1', '1', 'articles', '', '', '', 'welcome-to-your-site', '', '', '', '', '', '', '', '', '', '', '".md5(uniqid(rand(), true))."', NOW())";
 
 $create_sql[] = "CREATE TABLE `".PFX."txp_category` (
     id          INT          NOT NULL AUTO_INCREMENT,
@@ -212,7 +212,7 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_discuss` (
     email     VARCHAR(254)    NOT NULL DEFAULT '',
     web       VARCHAR(255)    NOT NULL DEFAULT '',
     ip        VARCHAR(100)    NOT NULL DEFAULT '',
-    posted    DATETIME        NOT NULL DEFAULT '0000-00-00 00:00:00',
+    posted    DATETIME        NOT NULL,
     message   TEXT            NOT NULL,
     visible   TINYINT         NOT NULL DEFAULT '1',
 
@@ -223,7 +223,7 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_discuss` (
 $create_sql[] = "INSERT INTO `".PFX."txp_discuss` VALUES (000001, 1, 'Donald Swain', 'donald.swain@example.com', 'example.com', '127.0.0.1', NOW(), '<p>I enjoy your site very much.</p>', 1)";
 
 $create_sql[] = "CREATE TABLE `".PFX."txp_discuss_nonce` (
-    issue_time DATETIME     NOT NULL DEFAULT '0000-00-00 00:00:00',
+    issue_time DATETIME     NOT NULL,
     nonce      VARCHAR(255) NOT NULL DEFAULT '',
     used       TINYINT      NOT NULL DEFAULT '0',
     secret     VARCHAR(255) NOT NULL DEFAULT '',
@@ -235,13 +235,13 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_file` (
     id          INT          NOT NULL AUTO_INCREMENT,
     filename    VARCHAR(255) NOT NULL DEFAULT '',
     title       VARCHAR(255) DEFAULT NULL,
-    category    VARCHAR(255) NOT NULL DEFAULT '',
+    category    VARCHAR(64)  NOT NULL DEFAULT '',
     permissions VARCHAR(32)  NOT NULL DEFAULT '0',
     description TEXT         NOT NULL,
     downloads   INT UNSIGNED NOT NULL DEFAULT '0',
     status	SMALLINT     NOT NULL DEFAULT '4',
-    modified    DATETIME     NOT NULL DEFAULT '0000-00-00 00:00:00',
-    created     DATETIME     NOT NULL DEFAULT '0000-00-00 00:00:00',
+    modified    DATETIME     NOT NULL,
+    created     DATETIME     NOT NULL,
     size        BIGINT       DEFAULT NULL,
     author      VARCHAR(64)  NOT NULL DEFAULT '',
 
@@ -269,13 +269,13 @@ foreach(scandir($themedir.DS.'forms') as $formfile) {
 $create_sql[] = "CREATE TABLE `".PFX."txp_image` (
     id        INT          NOT NULL AUTO_INCREMENT,
     name      VARCHAR(255) NOT NULL DEFAULT '',
-    category  VARCHAR(255) NOT NULL DEFAULT '',
+    category  VARCHAR(64)  NOT NULL DEFAULT '',
     ext       VARCHAR(20)  NOT NULL DEFAULT '',
     w         INT          NOT NULL DEFAULT '0',
     h         INT          NOT NULL DEFAULT '0',
     alt       VARCHAR(255) NOT NULL DEFAULT '',
     caption   TEXT         NOT NULL,
-    date      DATETIME     NOT NULL DEFAULT '0000-00-00 00:00:00',
+    date      DATETIME     NOT NULL,
     author    VARCHAR(64)  NOT NULL DEFAULT '',
     thumbnail INT          NOT NULL DEFAULT '0',
     thumb_w   INT          NOT NULL DEFAULT '0',
@@ -302,7 +302,7 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_lang` (
 
 $create_sql[] = "CREATE TABLE `".PFX."txp_link` (
     id          INT          NOT NULL AUTO_INCREMENT,
-    date        DATETIME     NOT NULL DEFAULT '0000-00-00 00:00:00',
+    date        DATETIME     NOT NULL,
     category    VARCHAR(64)  NOT NULL DEFAULT '',
     url         TEXT         NOT NULL,
     linkname    VARCHAR(255) NOT NULL DEFAULT '',
@@ -323,7 +323,7 @@ $create_sql[] = "INSERT INTO `".PFX."txp_link` VALUES (6, NOW(), 'textpattern', 
 
 $create_sql[] = "CREATE TABLE `".PFX."txp_log` (
     id     INT          NOT NULL AUTO_INCREMENT,
-    time   DATETIME     NOT NULL DEFAULT '0000-00-00 00:00:00',
+    time   DATETIME     NOT NULL,
     host   VARCHAR(255) NOT NULL DEFAULT '',
     page   VARCHAR(255) NOT NULL DEFAULT '',
     refer  MEDIUMTEXT   NOT NULL,
@@ -529,7 +529,7 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_users` (
     RealName    VARCHAR(255) NOT NULL DEFAULT '',
     email       VARCHAR(254) NOT NULL DEFAULT '',
     privs       TINYINT      NOT NULL DEFAULT '1',
-    last_access DATETIME     NOT NULL DEFAULT '0000-00-00 00:00:00',
+    last_access DATETIME         NULL DEFAULT NULL,
     nonce       VARCHAR(64)  NOT NULL DEFAULT '',
 
     PRIMARY KEY (user_id),
@@ -545,6 +545,17 @@ $create_sql[] = "INSERT INTO `".PFX."txp_users` VALUES (
     1,
     NOW(),
     '".md5(uniqid(rand(), true))."')";
+
+$create_sql[] = "CREATE TABLE `".PFX."txp_token` (
+    id           INT          NOT NULL AUTO_INCREMENT,
+    reference_id INT          NOT NULL DEFAULT 0,
+    type         VARCHAR(255) NOT NULL DEFAULT '',
+    selector     VARCHAR(12)  NOT NULL DEFAULT '',
+    token        VARCHAR(255) NOT NULL DEFAULT '',
+    expires      DATETIME     NOT NULL,
+
+    PRIMARY KEY (id)
+) $tabletype ";
 
 $GLOBALS['txp_install_successful'] = true;
 $GLOBALS['txp_err_count'] = 0;
@@ -572,7 +583,7 @@ if (!$client->query('tups.getLanguage', $blog_uid, LANG)) {
         include_once txpath.'/setup/en-gb.php';
 
         if (!@$lastmod) {
-            $lastmod = '0000-00-00 00:00:00';
+            $lastmod = '1970-01-01 00:00:00';
         }
 
         foreach ($en_gb_lang as $evt_name => $evt_strings) {

--- a/textpattern/update/_to_1.0.0.php
+++ b/textpattern/update/_to_1.0.0.php
@@ -345,7 +345,7 @@ if (!safe_query("SELECT 1 FROM `".PFX."txp_file` LIMIT 0")) {
     safe_query("CREATE TABLE `".PFX."txp_file` (
         id          INT          NOT NULL AUTO_INCREMENT,
         filename    VARCHAR(255) NOT NULL DEFAULT '',
-        category    VARCHAR(255) NOT NULL DEFAULT '',
+        category    VARCHAR(64)  NOT NULL DEFAULT '',
         permissions VARCHAR(32)  NOT NULL DEFAULT '0',
         description TEXT         NOT NULL DEFAULT '',
         downloads   INT UNSIGNED NOT NULL DEFAULT '0',
@@ -422,7 +422,9 @@ if (safe_field("val", 'txp_prefs', "name = 'blog_time_uid'") === false) {
 // Articles unique id.
 if (!in_array('uid', $txp)) {
     safe_alter('textpattern', "ADD uid VARCHAR(32) NOT NULL");
-    safe_alter('textpattern', "ADD feed_time DATE NOT NULL DEFAULT '0000-00-00'");
+    safe_alter('textpattern', "ADD feed_time DATE NOT NULL DEFAULT 1970-01-01");
+    safe_update('textpattern', "feed_time = DATE(Posted)", "feed_time = '1970-01-01'");
+    safe_alter('textpattern', "MODIFY feed_time DATE NOT NULL");
 
     $rs = safe_rows_start('ID, Posted', 'textpattern', '1');
 

--- a/textpattern/update/_to_4.0.5.php
+++ b/textpattern/update/_to_4.0.5.php
@@ -41,18 +41,19 @@ if (!in_array('status', $txpfile)) {
 $update_files = 0;
 
 if (!in_array('modified', $txpfile)) {
-    safe_alter('txp_file', "ADD modified DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00'");
+    safe_alter('txp_file', "ADD modified DATETIME NOT NULL DEFAULT '1970-01-01 00:00:00'");
+    safe_alter('txp_file', "MODIFY modified DATETIME NOT NULL");
     $update_files = 1;
 }
 
 if (!in_array('created', $txpfile)) {
-    safe_alter('txp_file', "ADD created DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00'");
+    safe_alter('txp_file', "ADD created DATETIME NOT NULL DEFAULT '1970-01-01 00:00:00'");
+    safe_alter('txp_file', "MODIFY created DATETIME NOT NULL");
     $update_files = 1;
 }
 
 if (!in_array('size', $txpfile)) {
-    safe_alter('txp_file',
-        "ADD size BIGINT");
+    safe_alter('txp_file', "ADD size BIGINT");
     $update_files = 1;
 }
 
@@ -61,9 +62,8 @@ if (!in_array('downloads', $txpfile)) {
 }
 
 if (array_intersect(array('modified', 'created'), $txpfile)) {
-    safe_alter('txp_file', "
-        MODIFY modified DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
-        MODIFY created DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00'");
+    safe_alter('txp_file', "MODIFY modified DATETIME NOT NULL");
+    safe_alter('txp_file', "MODIFY created  DATETIME NOT NULL");
 }
 
 // Copy existing file timestamps into the new database columns.

--- a/textpattern/update/_to_4.0.7.php
+++ b/textpattern/update/_to_4.0.7.php
@@ -49,7 +49,7 @@ if (!safe_field("val", 'txp_prefs', "name = 'author_list_pageby'")) {
 $txp = getThings("DESCRIBE `".PFX."textpattern`");
 
 if (!in_array('Expires', $txp)) {
-    safe_alter('textpattern', "ADD Expires DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER Posted");
+    safe_alter('textpattern', "ADD Expires DATETIME AFTER Posted");
 }
 
 safe_create_index('textpattern', 'Expires', 'Expires_idx');

--- a/textpattern/update/_to_4.6.0.php
+++ b/textpattern/update/_to_4.6.0.php
@@ -204,14 +204,49 @@ safe_drop_index('txp_section', "name");
 // The txp_priv table was created for version 1.0, but never used nor created in later versions.
 safe_drop('txp_priv');
 
-// Add generic token table.
+// Add generic token table (dropping first, because of changes to the table setup)
+safe_drop('txp_token');
 safe_create('txp_token',"
-id           INT          NOT NULL AUTO_INCREMENT,
-reference_id INT          DEFAULT 0,
-type         VARCHAR(255) DEFAULT '',
-selector     CHAR(12)     DEFAULT '',
-token        VARCHAR(255) DEFAULT '',
-expires      DATETIME     DEFAULT '0000-00-00 00:00:00',
-PRIMARY KEY (id)
-"
-);
+    id           INT          NOT NULL AUTO_INCREMENT,
+    reference_id INT          NOT NULL DEFAULT 0,
+    type         VARCHAR(255) NOT NULL DEFAULT '',
+    selector     VARCHAR(12)  NOT NULL DEFAULT '',
+    token        VARCHAR(255) NOT NULL DEFAULT '',
+    expires      DATETIME     NOT NULL,
+
+    PRIMARY KEY (id)
+");
+
+// Get rid of default zero dates to make MySQL 5.7 happy.
+safe_alter('textpattern',       "MODIFY Posted      DATETIME NOT NULL");
+safe_alter('textpattern',       "MODIFY Expires     DATETIME     NULL DEFAULT NULL");
+safe_alter('textpattern',       "MODIFY LastMod     DATETIME NOT NULL");
+safe_alter('textpattern',       "MODIFY feed_time   DATE     NOT NULL"); //0000-00-00
+safe_alter('txp_discuss',       "MODIFY posted      DATETIME NOT NULL");
+safe_alter('txp_discuss_nonce', "MODIFY issue_time  DATETIME NOT NULL");
+safe_alter('txp_file',          "MODIFY created     DATETIME NOT NULL");
+safe_alter('txp_file',          "MODIFY modified    DATETIME NOT NULL");
+safe_alter('txp_image',         "MODIFY date        DATETIME NOT NULL");
+safe_alter('txp_link',          "MODIFY date        DATETIME NOT NULL");
+safe_alter('txp_log',           "MODIFY time        DATETIME NOT NULL");
+safe_alter('txp_users',         "MODIFY last_access DATETIME     NULL DEFAULT NULL");
+// remove logs and nonces with zero dates.
+safe_delete('txp_discuss_nonce', "DATE(issue_time) = '0000-00-00'");
+safe_delete('txp_log',           "DATE(time)       = '0000-00-00'");
+// replace zero dates (which shouldn't exist, really) with somewhat sensible values
+safe_update('textpattern', "Posted      = NOW()",   "DATE(Posted)      = '0000-00-00'");
+safe_update('textpattern', "Expires     = NULL",    "DATE(Expires)     = '0000-00-00'");
+safe_update('textpattern', "LastMod     = Posted",  "DATE(LastMod)     = '0000-00-00'");
+safe_update('txp_discuss', "posted      = NOW()",   "DATE(posted)      = '0000-00-00'");
+safe_update('txp_file',    "created     = NOW()",   "DATE(created)     = '0000-00-00'");
+safe_update('txp_file',    "modified    = created", "DATE(modified)    = '0000-00-00'");
+safe_update('txp_image',   "date        = NOW()",   "DATE(date)        = '0000-00-00'");
+safe_update('txp_link',    "date        = NOW()",   "DATE(date)        = '0000-00-00'");
+safe_update('txp_users',   "last_access = NULL",    "DATE(last_access) = '0000-00-00'");
+safe_update('textpattern', "feed_time   = DATE(Posted)", "feed_time    = '0000-00-00'");
+
+// category names are max 64 chars when created/edited, so don't pretend they can be longer
+safe_alter('textpattern', "MODIFY Category1 VARCHAR(64) NOT NULL DEFAULT ''");
+safe_alter('textpattern', "MODIFY Category2 VARCHAR(64) NOT NULL DEFAULT ''");
+safe_alter('txp_file',    "MODIFY category  VARCHAR(64) NOT NULL DEFAULT ''");
+safe_alter('txp_image',   "MODIFY category  VARCHAR(64) NOT NULL DEFAULT ''");


### PR DESCRIPTION
MySQL 5.7 by default no longer allows 0000-00-00 dates, which were used as the default on several columns in TXP tables.
This patch removes those defaults for NOT NULL columns and sets the default to NULL for NULL columns (textpattern:Expires and txp_users:last_access)
Zero dates in existing rows are converted to sensible values that are allowed.
This fixes issue #591 

Categories, when created or edited can be 64 chars long. A few other tables that used these categories allowed for longer names. That doesn't make sense, because they can't be longer than 64 chars, so I've changed those colums to varchar(64).

txp_token was added to the update scripts, but without NOT NULL and it was also missing from txpsql.php. Added it there and recreated the table to be more in line with the other tables.