### PR TITLE
Fix NULL regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ ehthumbs.db
 Thumbs.db
 /vendor
 /composer.lock
+*~

--- a/textpattern/include/txp_admin.php
+++ b/textpattern/include/txp_admin.php
@@ -700,9 +700,9 @@ function admin_multi_edit()
     $clause = '';
 
     if ($method === 'resetpassword') {
-        $clause = " AND last_access != " . NULLDATETIME;
+        $clause = " AND last_access IS NOT NULL";
     } elseif ($method === 'resendactivation') {
-        $clause = " AND last_access = " . NULLDATETIME;
+        $clause = " AND last_access IS NULL";
     }
 
     $names = safe_column(

--- a/textpattern/include/txp_article.php
+++ b/textpattern/include/txp_article.php
@@ -231,7 +231,7 @@ function article_post()
         if ($expires) {
             $whenexpires = "FROM_UNIXTIME($expires)";
         } else {
-            $whenexpires = NULLDATETIME;
+            $whenexpires = "NULL";
         }
 
         $user = doSlash($txp_user);
@@ -440,7 +440,7 @@ function article_save()
     if ($expires) {
         $whenexpires = "Expires = FROM_UNIXTIME($expires)";
     } else {
-        $whenexpires = "Expires = ".NULLDATETIME;
+        $whenexpires = "Expires = NULL";
     }
 
     // Auto-update custom-titles according to Title, as long as unpublished and

--- a/textpattern/lib/constants.php
+++ b/textpattern/lib/constants.php
@@ -178,14 +178,6 @@ if (!defined('REGEXP_UTF8')) {
 }
 
 /**
- * NULL datetime for use in an SQL statement.
- *
- * @package DB
- */
-
-define('NULLDATETIME', 'NULL');
-
-/**
  * Permlink URL mode.
  *
  * @package    URL

--- a/textpattern/lib/txplib_publish.php
+++ b/textpattern/lib/txplib_publish.php
@@ -115,9 +115,9 @@ function populateArticleData($rs)
 
 function article_format_info($rs)
 {
-    $rs['uPosted'] = (($unix_ts = @strtotime($rs['Posted'])) > 0) ? $unix_ts : NULLDATETIME;
-    $rs['uLastMod'] = (($unix_ts = @strtotime($rs['LastMod'])) > 0) ? $unix_ts : NULLDATETIME;
-    $rs['uExpires'] = (($unix_ts = @strtotime($rs['Expires'])) > 0) ? $unix_ts : NULLDATETIME;
+    $rs['uPosted']  = (($unix_ts = @strtotime($rs['Posted']))  !== false) ? $unix_ts : null;
+    $rs['uLastMod'] = (($unix_ts = @strtotime($rs['LastMod'])) !== false) ? $unix_ts : null;
+    $rs['uExpires'] = (($unix_ts = @strtotime($rs['Expires'])) !== false) ? $unix_ts : null;
     populateArticleData($rs);
 }
 
@@ -205,7 +205,7 @@ function getNeighbour($threshold, $s, $type, $atts = array(), $threshold_type = 
     }
 
     if (!$expired) {
-        $time .= " AND (".now('expires')." <= Expires OR Expires = ".NULLDATETIME.")";
+        $time .= " AND (".now('expires')." <= Expires OR Expires IS NULL)";
     }
 
     $custom = '';

--- a/textpattern/publish.php
+++ b/textpattern/publish.php
@@ -853,7 +853,7 @@ function doArticles($atts, $iscustom, $thing = null)
     }
 
     if (!$expired) {
-        $time .= " AND (".now('expires')." <= Expires OR Expires = ".NULLDATETIME.")";
+        $time .= " AND (".now('expires')." <= Expires OR Expires IS NULL)";
     }
 
     $custom = '';

--- a/textpattern/publish/atom.php
+++ b/textpattern/publish/atom.php
@@ -170,7 +170,7 @@ function atom()
         $query[] = $sfilter;
         $query[] = $cfilter;
 
-        $expired = ($publish_expired_articles) ? " " : " AND (".now('expires')." <= Expires OR Expires = ".NULLDATETIME.") ";
+        $expired = ($publish_expired_articles) ? " " : " AND (".now('expires')." <= Expires OR Expires IS NULL) ";
         $rs = safe_rows_start(
             "*,
             ID AS thisid,

--- a/textpattern/publish/rss.php
+++ b/textpattern/publish/rss.php
@@ -117,7 +117,7 @@ function rss()
         $query[] = $sfilter;
         $query[] = $cfilter;
 
-        $expired = ($publish_expired_articles) ? " " : " AND (".now('expires')." <= Expires OR Expires = ".NULLDATETIME.") ";
+        $expired = ($publish_expired_articles) ? " " : " AND (".now('expires')." <= Expires OR Expires IS NULL) ";
         $rs = safe_rows_start(
             "*, UNIX_TIMESTAMP(Posted) AS uPosted, UNIX_TIMESTAMP(LastMod) AS uLastMod, UNIX_TIMESTAMP(Expires) AS uExpires, ID AS thisid",
             'textpattern',

--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -1030,7 +1030,7 @@ function recent_articles($atts)
     $category = join("','", doSlash(do_list_unique($category)));
     $categories = ($category) ? "AND (Category1 IN ('".$category."') or Category2 IN ('".$category."'))" : '';
     $section = ($section) ? " AND Section IN ('".join("','", doSlash(do_list_unique($section)))."')" : '';
-    $expired = ($prefs['publish_expired_articles']) ? "" : " AND (".now('expires')." <= Expires OR Expires = ".NULLDATETIME.")";
+    $expired = ($prefs['publish_expired_articles']) ? "" : " AND (".now('expires')." <= Expires OR Expires IS NULL)";
 
     $rs = safe_rows_start("*, id AS thisid, UNIX_TIMESTAMP(Posted) AS posted", 'textpattern',
         "Status = ".STATUS_LIVE." $section $categories AND Posted <= ".now('posted').$expired." ORDER BY ".doSlash($sort)." LIMIT ".intval($offset).", ".intval($limit));
@@ -1071,7 +1071,7 @@ function recent_comments($atts, $thing = null)
     ), $atts));
 
     $sort = preg_replace('/\bposted\b/', 'd.posted', $sort);
-    $expired = ($prefs['publish_expired_articles']) ? '' : " AND (".now('expires')." <= t.Expires OR t.Expires = ".NULLDATETIME.") ";
+    $expired = ($prefs['publish_expired_articles']) ? '' : " AND (".now('expires')." <= t.Expires OR t.Expires IS NULL) ";
 
     $rs = startRows("SELECT d.name, d.email, d.web, d.message, d.discussid, UNIX_TIMESTAMP(d.Posted) AS time,
             t.ID AS thisid, UNIX_TIMESTAMP(t.Posted) AS posted, t.Title AS title, t.Section AS section, t.url_title
@@ -1184,7 +1184,7 @@ function related_articles($atts, $thing = null)
 
     $section = ($section) ? " AND Section IN ('".join("','", doSlash(do_list_unique($section)))."')" : '';
 
-    $expired = ($prefs['publish_expired_articles']) ? '' : " AND (".now('expires')." <= Expires OR Expires = ".NULLDATETIME.") ";
+    $expired = ($prefs['publish_expired_articles']) ? '' : " AND (".now('expires')." <= Expires OR Expires IS NULL) ";
     $rs = safe_rows_start(
         "*, UNIX_TIMESTAMP(Posted) AS posted, UNIX_TIMESTAMP(LastMod) AS uLastMod, UNIX_TIMESTAMP(Expires) AS uExpires",
         'textpattern',

--- a/textpattern/setup/txpsql.php
+++ b/textpattern/setup/txpsql.php
@@ -109,7 +109,7 @@ $create_sql = array();
 $create_sql[] = "CREATE TABLE `".PFX."textpattern` (
     ID              INT          NOT NULL AUTO_INCREMENT,
     Posted          DATETIME     NOT NULL,
-    Expires         DATETIME     NOT NULL,
+    Expires         DATETIME         NULL DEFAULT NULL,
     AuthorID        VARCHAR(64)  NOT NULL DEFAULT '',
     LastMod         DATETIME     NOT NULL,
     LastModID       VARCHAR(64)  NOT NULL DEFAULT '',
@@ -144,7 +144,7 @@ $create_sql[] = "CREATE TABLE `".PFX."textpattern` (
     custom_9        VARCHAR(255) NOT NULL DEFAULT '',
     custom_10       VARCHAR(255) NOT NULL DEFAULT '',
     uid             VARCHAR(32)  NOT NULL DEFAULT '',
-    feed_time       DATE         NOT NULL DEFAULT,
+    feed_time       DATE         NOT NULL,
 
     PRIMARY KEY                 (ID),
     INDEX    categories_idx     (Category1(10), Category2(10)),
@@ -552,7 +552,7 @@ $create_sql[] = "CREATE TABLE `".PFX."txp_token` (
     type         VARCHAR(255) NOT NULL DEFAULT '',
     selector     VARCHAR(12)  NOT NULL DEFAULT '',
     token        VARCHAR(255) NOT NULL DEFAULT '',
-    expires      DATETIME     NOT NULL,
+    expires      DATETIME         NULL DEFAULT NULL,
 
     PRIMARY KEY (id)
 ) $tabletype ";

--- a/textpattern/update/_to_4.6.0.php
+++ b/textpattern/update/_to_4.6.0.php
@@ -212,7 +212,7 @@ safe_create('txp_token',"
     type         VARCHAR(255) NOT NULL DEFAULT '',
     selector     VARCHAR(12)  NOT NULL DEFAULT '',
     token        VARCHAR(255) NOT NULL DEFAULT '',
-    expires      DATETIME     NOT NULL,
+    expires      DATETIME         NULL DEFAULT NULL,
 
     PRIMARY KEY (id)
 ");


### PR DESCRIPTION
Fix a few regressions caused by my earlier patch which removed zero dates.
This now does affect plugins that use the Expired column in the textpattern table. I removed the NULLDATETIME constant, because if you change it from NULL to something else, you also have to modify a lot of queries. No point in having it as a constant anymore.

PS. Please add "*~" to .gitignore (to exclude backup files created by unix text editors.)