### PR TITLE
More consistent duplicate behaviour

### DIFF
--- a/textpattern/include/txp_article.php
+++ b/textpattern/include/txp_article.php
@@ -163,7 +163,7 @@ function article_post()
         $Annotate = (int) $Annotate;
 
         // Set and validate article timestamp.
-        if ($publish_now == 1) {
+        if ($publish_now == 1 || $reset_time == 1) {
             $when = "NOW()";
             $when_ts = time();
         } else {
@@ -183,10 +183,6 @@ function article_post()
             $when_ts = $ts - tz_offset($ts);
             $when = "FROM_UNIXTIME($when_ts)";
         }
-
-        // Force a reasonable 'last modified' date for future articles,
-        // keep recent articles list in order.
-        $lastmod = ($when_ts > time() ? "NOW()" : $when);
 
         // Set and validate expiry timestamp.
         if (empty($exp_year)) {
@@ -278,7 +274,7 @@ function article_post()
                 Posted          =  $when,
                 Expires         =  $whenexpires,
                 AuthorID        = '$user',
-                LastMod         =  $lastmod,
+                LastMod         = NOW(),
                 LastModID       = '$user',
                 Section         = '$Section',
                 Category1       = '$Category1',

--- a/textpattern/include/txp_list.php
+++ b/textpattern/include/txp_list.php
@@ -699,9 +699,11 @@ function list_multi_edit()
 
             if ($rs) {
                 while ($a = nextRow($rs)) {
-                    unset($a['ID'], $a['LastMod'], $a['LastModID'], $a['Expires']);
+                    unset($a['ID'], $a['comments_count']);
                     $a['uid'] = md5(uniqid(rand(), true));
                     $a['AuthorID'] = $txp_user;
+                    $a['LastModID'] = $txp_user;
+                    $a['Status'] = ($a['Status'] >= STATUS_LIVE) ? STATUS_DRAFT : $a['Status'];
 
                     foreach ($a as $name => &$value) {
                         $value = "`$name` = '".doSlash($value)."'";
@@ -710,10 +712,10 @@ function list_multi_edit()
                     if ($id = (int) safe_insert('textpattern', join(',', $a))) {
                         safe_update(
                             'textpattern',
-                            "Title = CONCAT(Title, ' (', $id, ')'),
-                            url_title = CONCAT(url_title, '-', $id),
-                            Posted = NOW(),
-                            feed_time = NOW()",
+                            "Title     = CONCAT(Title, ' (', $id, ')'),
+                             url_title = CONCAT(url_title, '-', $id),
+                             LastMod   = NOW(),
+                             feed_time = NOW()",
                             "ID = $id"
                         );
                     }


### PR DESCRIPTION
Fixes issue #614. Changes are:

Duplicate from article write tab:
* reset posted time if that option is checked.
* always set last modified time to NOW.

Duplicate from articles list tab:
* don't change Posted and Expires dates.
* reset comments_count to zero.
* set last modified time to NOW (fixes issue #618).
* set status to draft if the old status was live/sticky

One difference remains. On the write tab, the url_title is regenerated from the title when duplicating. On the articles list tab, this doesn't happen.

Side effect: for new articles, the last modified time is now always set to NOW(). Previously, for articles set in the future it was set to the posted date. However when editing such an article, it would be reset to NOW(), so that didn't make much sense.