### PR TITLE
Improve comment error handling

### DIFF
--- a/textpattern/publish.php
+++ b/textpattern/publish.php
@@ -179,12 +179,16 @@ if (!empty($feed) && in_array($feed, array('atom', 'rss'), true)) {
     exit;
 }
 
-if (gps('parentid') && gps('submit')) {
-    saveComment();
-} elseif (gps('parentid') and $comments_mode == 1) {
-    // Popup comments?
-    header("Content-type: text/html; charset=utf-8");
-    exit(parse_form('popup_comments'));
+if (gps('parentid')) {
+    if (ps('submit')) {
+        saveComment();
+    } elseif (ps('preview')) {
+        checkCommentRequired(getComment());
+    } elseif ($comments_mode == 1) {
+        // Popup comments?
+        header("Content-type: text/html; charset=utf-8");
+        exit(parse_form('popup_comments'));
+    }
 }
 
 // We are dealing with a download.

--- a/textpattern/publish/comment.php
+++ b/textpattern/publish/comment.php
@@ -138,7 +138,7 @@ function destroyCookies()
  * );
  */
 
-function getComment()
+function getComment($obfuscated = false)
 {
     $c = psa(array(
         'parentid',
@@ -166,7 +166,15 @@ function getComment()
         $c['nonce'] = $rs['nonce'];
         $c['secret'] = $rs['secret'];
     }
-    $c['message'] = ps(md5('message'.$c['secret']));
+
+    if ($obfuscated || $c['message'] == '') {
+        $c['message'] = ps(md5('message'.$c['secret']));
+    }
+
+    $c['name']    = trim(strip_tags(deEntBrackets($c['name'])));
+    $c['web']     = trim(clean_url(strip_tags(deEntBrackets($c['web']))));
+    $c['email']   = trim(clean_url(strip_tags(deEntBrackets($c['email']))));
+    $c['message'] = trim(substr(trim(doDeEnt($c['message'])), 0, 65535));
 
     return $c;
 }
@@ -180,10 +188,10 @@ function saveComment()
     global $siteurl, $comments_moderate, $comments_sendmail, $comments_disallow_images, $prefs;
 
     $ref = serverset('HTTP_REFERRER');
-    $in = getComment();
+    $comment = getComment(true);
     $evaluator = & get_comment_evaluator();
 
-    extract($in);
+    extract($comment);
 
     if (!checkCommentsAllowed($parentid)) {
         txp_die(gTxt('comments_closed'), '403');
@@ -196,37 +204,24 @@ function saveComment()
         txp_die(gTxt('your_ip_is_blacklisted_by'.' '.$blacklisted), '403');
     }
 
-    $web = clean_url($web);
-    $email = clean_url($email);
-
     if ($remember == 1 || ps('checkbox_type') == 'forget' && ps('forget') != 1) {
         setCookies($name, $email, $web);
     } else {
         destroyCookies();
     }
 
-    $name = doSlash(strip_tags(deEntBrackets($name)));
-    $web = doSlash(strip_tags(deEntBrackets($web)));
-    $email = doSlash(strip_tags(deEntBrackets($email)));
-    $message = substr(trim($message), 0, 65535);
-    $message2db = doSlash(markup_comment($message));
+    $message2db = markup_comment($message);
 
     $isdup = safe_row(
         "message, name",
         'txp_discuss',
-        "name = '$name' AND message = '$message2db' AND ip = '".doSlash($ip)."'"
+        "name = '".doSlash($name)."' AND message = '".doSlash($message2db)."' AND ip = '".doSlash($ip)."'"
     );
 
-    if (
-        ($prefs['comments_require_name'] && !trim($name)) ||
-        ($prefs['comments_require_email'] && !trim($email)) ||
-        (!trim($message))
-    ) {
-        $evaluator->add_estimate(RELOAD, 1); // The error-messages are added in the preview-code.
-    }
+    checkCommentRequired($comment);
 
     if ($isdup) {
-        $evaluator->add_estimate(RELOAD, 1); // FIXME? Tell the user about dupe?
+        $evaluator->add_estimate(RELOAD, 1, gTxt('comment_duplicate'));
     }
 
     if (($evaluator->get_result() != RELOAD) && checkNonce($nonce)) {
@@ -238,11 +233,11 @@ function saveComment()
             $commentid = safe_insert(
                 'txp_discuss',
                 "parentid = $parentid,
-                 name     = '$name',
-                 email    = '$email',
-                 web      = '$web',
+                 name     = '".doSlash($name)."',
+                 email    = '".doSlash($email)."',
+                 web      = '".doSlash($web)."',
                  ip       = '".doSlash($ip)."',
-                 message  = '$message2db',
+                 message  = '".doSlash($message2db)."',
                  visible  = ".intval($visible).",
                  posted   = NOW()"
             );
@@ -296,6 +291,31 @@ function saveComment()
     // Force another Preview.
     $_POST['preview'] = RELOAD;
     //$evaluator->write_trace();
+}
+
+/**
+ * Checks if all required comment fields are filled out.
+ *
+ * To be used only by TXP itself
+ *
+ * @param array comment fields (from getComment())
+ */
+
+function checkCommentRequired($comment)
+{
+    global $prefs;
+
+    $evaluator = & get_comment_evaluator();
+
+    if ($prefs['comments_require_name'] && !$comment['name']) {
+        $evaluator->add_estimate(RELOAD, 1, gTxt('comment_name_required'));
+    }
+    if ($prefs['comments_require_email'] && !$comment['email']) {
+        $evaluator->add_estimate(RELOAD, 1, gTxt('comment_email_required'));
+    }
+    if (!$comment['message']) {
+        $evaluator->add_estimate(RELOAD, 1, gTxt('comment_required'));
+    }
 }
 
 /**

--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -2268,13 +2268,8 @@ function comment_name_input($atts)
     $h5 = ($prefs['doctype'] == 'html5');
 
     if (ps('preview')) {
-        $name  = ps('name');
-        $namewarn = ($prefs['comments_require_name'] && !trim($name));
-
-        if ($namewarn) {
-            $evaluator = & get_comment_evaluator();
-            $evaluator->add_estimate(RELOAD, 1, gTxt('comment_name_required'));
-        }
+        $name = getComment()['name'];
+        $namewarn = ($prefs['comments_require_name'] && !$name);
     }
 
     return fInput('text', 'name', $name, 'comment_name_input'.($namewarn ? ' comments_error' : ''), '', '', $size, '', 'name', false, $h5 && $prefs['comments_require_name']);
@@ -2295,13 +2290,8 @@ function comment_email_input($atts)
     $h5 = ($prefs['doctype'] == 'html5');
 
     if (ps('preview')) {
-        $email  = clean_url(ps('email'));
-        $emailwarn = ($prefs['comments_require_email'] && !trim($email));
-
-        if ($emailwarn) {
-            $evaluator = & get_comment_evaluator();
-            $evaluator->add_estimate(RELOAD, 1, gTxt('comment_email_required'));
-        }
+        $email = getComment()['email'];
+        $emailwarn = ($prefs['comments_require_email'] && !$email);
     }
 
     return fInput($h5 ? 'email' : 'text', 'email', $email, 'comment_email_input'.($emailwarn ? ' comments_error' : ''), '', '', $size, '', 'email', false, $h5 && $prefs['comments_require_email']);
@@ -2321,7 +2311,7 @@ function comment_web_input($atts)
     $h5 = ($prefs['doctype'] == 'html5');
 
     if (ps('preview')) {
-        $web  = clean_url(ps('web'));
+        $web = getComment()['web'];
     }
 
     return fInput($h5 ? 'text' : 'text', 'web', $web, 'comment_web_input', '', '', $size, '', 'web', false, false); /* TODO: maybe use type = 'url' once browsers are less strict */
@@ -2342,14 +2332,10 @@ function comment_message_input($atts)
     $commentwarn = false;
     $n_message = 'message';
     $formnonce = '';
-    $message = doDeEnt(ps('message'));
-
-    if ($message == '') { // Second or later preview will have randomised message-field name.
-        $in = getComment();
-        $message = doDeEnt($in['message']);
-    }
+    $message = '';
 
     if (ps('preview')) {
+        $message = getComment()['message'];
         $split = rand(1, 31);
         $nonce = getNextNonce();
         $secret = getNextSecret();
@@ -2357,11 +2343,6 @@ function comment_message_input($atts)
         $n_message = md5('message'.$secret);
         $formnonce = n.hInput(substr($nonce, 0, $split), substr($nonce, $split));
         $commentwarn = (!trim($message));
-
-        if ($commentwarn) {
-            $evaluator = & get_comment_evaluator();
-            $evaluator->add_estimate(RELOAD, 1, gTxt('comment_required'));
-        }
     }
 
     $required = ($prefs['doctype'] == 'html5') ? ' required' : '';


### PR DESCRIPTION
Put all the cleanup of comment form field values into the getComment() function. The advantage being that we get the same type of cleanup everwhere we use these values.

Evaluate required fields during preview at a much earlier stage, allowing errors to be shown even if the errors are to be displayed before the comment form fields. Fixes issue #623.

Add language string: comment_duplicate, which is an error message indicating that the comment was rejected, because the message was a duplicate (already exists in database).