### PR TITLE
Preserve attr="0" in html tags (newly) created with "tag" functions by default

### DIFF
--- a/textpattern/include/txp_list.php
+++ b/textpattern/include/txp_list.php
@@ -472,7 +472,7 @@ function list_list($message = '', $post = '')
                     $Category2, '', 'txp-list-col-category2 category articles_detail'.$vc[2]
                 ).
                 td(
-                    href($Status, $view_url, join_atts(array('title' => gTxt('view')))), '', 'txp-list-col-status'
+                    href($Status, $view_url, join_atts(array('title' => gTxt('view')), TEXTPATTERN_STRIP_EMPTY)), '', 'txp-list-col-status'
                 ).
                 (
                     $show_authors

--- a/textpattern/lib/txplib_db.php
+++ b/textpattern/lib/txplib_db.php
@@ -391,9 +391,15 @@ function safe_query($q = '', $debug = false, $unbuf = false)
         dmp($q);
     }
 
-    $trace->start("[SQL: $q ]", true);
+    if ($production_status !== 'live') {
+        $trace->start("[SQL: $q ]", true);
+    }
+    
     $result = mysqli_query($DB->link, $q, $method);
-    $trace->stop();
+    
+    if ($production_status !== 'live') {
+        $trace->stop();
+    }
 
     if ($result === false) {
         trigger_error(mysqli_error($DB->link), E_USER_ERROR);

--- a/textpattern/lib/txplib_forms.php
+++ b/textpattern/lib/txplib_forms.php
@@ -155,7 +155,7 @@ function selectInput($name = '', $array = array(), $value = '', $blank_first = f
         'id'       => $select_id,
         'name'     => $name,
         'disabled' => (bool) $disabled,
-    ));
+    ), TEXTPATTERN_STRIP_EMPTY);
 
     if ((string) $onchange === '1') {
         $atts .= ' data-submit-on="change"';
@@ -260,7 +260,7 @@ function fInput($type, $name, $value, $class = '', $title = '', $onClick = '', $
         'disabled'    => (bool) $disabled,
         'required'    => (bool) $required,
         'placeholder' => $placeholder,
-    ));
+    ), TEXTPATTERN_STRIP_EMPTY);
 
     if ($type != 'file' && $type != 'image') {
         $atts .= join_atts(array('value' => (string) $value), 0);
@@ -379,7 +379,7 @@ function checkbox($name, $value, $checked = true, $tabindex = 0, $id = '')
         'type'     => 'checkbox',
         'checked'  => (bool) $checked,
         'tabindex' => (int) $tabindex,
-    ));
+    ), TEXTPATTERN_STRIP_EMPTY);
 
     $atts .= join_atts(array('value' => (string) $value), 0);
 
@@ -429,7 +429,7 @@ function radio($name, $value, $checked = true, $id = '', $tabindex = 0)
         'type'     => 'radio',
         'checked'  => (bool) $checked,
         'tabindex' => (int) $tabindex,
-    ));
+    ), TEXTPATTERN_STRIP_EMPTY);
 
     $atts .= join_atts(array('value' => (string) $value), 0);
 

--- a/textpattern/lib/txplib_forms.php
+++ b/textpattern/lib/txplib_forms.php
@@ -263,7 +263,7 @@ function fInput($type, $name, $value, $class = '', $title = '', $onClick = '', $
     ), TEXTPATTERN_STRIP_EMPTY);
 
     if ($type != 'file' && $type != 'image') {
-        $atts .= join_atts(array('value' => (string) $value), 0);
+        $atts .= join_atts(array('value' => (string) $value), TEXTPATTERN_STRIP_NONE);
     }
 
     return n.tag_void('input', $atts);
@@ -381,7 +381,7 @@ function checkbox($name, $value, $checked = true, $tabindex = 0, $id = '')
         'tabindex' => (int) $tabindex,
     ), TEXTPATTERN_STRIP_EMPTY);
 
-    $atts .= join_atts(array('value' => (string) $value), 0);
+    $atts .= join_atts(array('value' => (string) $value), TEXTPATTERN_STRIP_NONE);
 
     return n.tag_void('input', $atts);
 }
@@ -431,7 +431,7 @@ function radio($name, $value, $checked = true, $id = '', $tabindex = 0)
         'tabindex' => (int) $tabindex,
     ), TEXTPATTERN_STRIP_EMPTY);
 
-    $atts .= join_atts(array('value' => (string) $value), 0);
+    $atts .= join_atts(array('value' => (string) $value), TEXTPATTERN_STRIP_NONE);
 
     return n.tag_void('input', $atts);
 }

--- a/textpattern/lib/txplib_html.php
+++ b/textpattern/lib/txplib_html.php
@@ -689,7 +689,7 @@ function startTable($id = '', $align = '', $class = '', $p = 0, $w = 0)
         'cellpadding' => (int) $p,
         'width'       => (int) $w,
         'align'       => $align,
-    ));
+    ), TEXTPATTERN_STRIP_EMPTY);
 
     return n.'<table'.$atts.'>';
 }

--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -3101,7 +3101,9 @@ function safe_strtotime($time_str)
 {
     $ts = strtotime($time_str);
 
-    return strtotime($time_str, time() + tz_offset($ts)) - tz_offset($ts);
+    // tz_offset calculations are expensive
+    $tz_offset = tz_offset($ts);
+    return strtotime($time_str, time() + $tz_offset) - $tz_offset;
 }
 
 /**
@@ -5176,7 +5178,7 @@ function join_qs($q)
  * or for 'href' and 'src' to a URL encoded query string.
  *
  * @param   array|string  $atts  HTML attributes
- * @param   int           $flags TEXTPATTERN_STRIP_EMPTY
+ * @param   int           $flags TEXTPATTERN_STRIP_EMPTY_STRING
  * @return  string HTML attribute list
  * @since   4.6.0
  * @package HTML

--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -5184,7 +5184,7 @@ function join_qs($q)
  * echo join_atts(array('class' => 'myClass', 'disabled' => true));
  */
 
-function join_atts($atts, $flags = TEXTPATTERN_STRIP_EMPTY)
+function join_atts($atts, $flags = TEXTPATTERN_STRIP_EMPTY_STRING)
 {
     if (!is_array($atts)) {
         return $atts ? ' '.trim($atts) : '';
@@ -5193,7 +5193,7 @@ function join_atts($atts, $flags = TEXTPATTERN_STRIP_EMPTY)
     $list = array();
 
     foreach ($atts as $name => $value) {
-        if (($flags & TEXTPATTERN_STRIP_EMPTY && !$value) || $value === false) {
+        if (($flags & TEXTPATTERN_STRIP_EMPTY && !$value) || ($flags & TEXTPATTERN_STRIP_EMPTY_STRING && $value === '') || ($value === false)) {
             continue;
         } elseif (is_array($value)) {
             if ($name == 'href' || $name == 'src') {

--- a/textpattern/publish.php
+++ b/textpattern/publish.php
@@ -850,12 +850,15 @@ function doArticles($atts, $iscustom, $thing = null)
     $category  = join("','", doSlash(do_list_unique($category)));
     $categories = array();
     $match = do_list_unique($match);
+
     if (in_array('Category1', $match)) {
         $categories[] = "Category1 IN ('$category')";
     }
+
     if (in_array('Category2', $match)) {
         $categories[] = "Category2 IN ('$category')";
     }
+
     $categories = join(" OR ", $categories);
     $category  = (!$category or !$categories)  ? '' : " AND ($categories)";
     $section   = (!$section)   ? '' : " AND Section IN ('".join("','", doSlash(do_list_unique($section)))."')";


### PR DESCRIPTION
If things go west, throw milestones and revert `function join_atts($atts, $flags = TEXTPATTERN_STRIP_EMPTY_STRING)` back to `function join_atts($atts, $flags = TEXTPATTERN_STRIP_EMPTY)` in `txplib_misc.php`