### PR TITLE
Specify where Textpattern-provided entries live & tweaks

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,4 @@
+# BEGIN Textpattern
 #DirectoryIndex index.php index.html
 
 #Options +FollowSymLinks
@@ -5,24 +6,24 @@
 #ErrorDocument 403 default
 
 <IfModule mod_rewrite.c>
-	RewriteEngine On
-	#RewriteBase /relative/web/path/
+    RewriteEngine On
+    #RewriteBase /relative/web/path/
 
-	RewriteCond %{REQUEST_FILENAME} -f [OR]
-	RewriteCond %{REQUEST_FILENAME} -d
-	RewriteRule ^(.+) - [PT,L]
+    RewriteCond %{REQUEST_FILENAME} -f [OR]
+    RewriteCond %{REQUEST_FILENAME} -d
+    RewriteRule ^(.+) - [PT,L]
 
-	RewriteCond %{REQUEST_URI} !=/favicon.ico
-	RewriteRule ^(.*) index.php
+    RewriteCond %{REQUEST_URI} !=/favicon.ico
+    RewriteRule ^(.*) index.php
 
-	RewriteCond %{HTTP:Authorization}  !^$
-	RewriteRule .* - [E=REMOTE_USER:%{HTTP:Authorization}]
+    RewriteCond %{HTTP:Authorization}  !^$
+    RewriteRule .* - [E=REMOTE_USER:%{HTTP:Authorization}]
 </IfModule>
 
 #php_value register_globals 0
 
-# SVG
 <IfModule mod_mime.c>
-	AddType image/svg+xml  svg svgz
-	AddEncoding gzip       svgz
+    AddType image/svg+xml  svg svgz
+    AddEncoding gzip       svgz
 </IfModule>
+# END Textpattern


### PR DESCRIPTION
Also remove the `# SVG` comment for uniformity. The other block doesn't have a comment, and it's pretty clear that the two lines refer to SVG stuff.

Tab indentation switched to four spaces, per other indentations.