### PR TITLE
Rewrite kusor.com refs to Wayback Machine

### DIFF
--- a/rpc/TXP_RPCServer.php
+++ b/rpc/TXP_RPCServer.php
@@ -5,10 +5,10 @@
  * http://textpattern.com
  *
  * XML-RPC Server for Textpattern 4.0.x
- * http://txp.kusor.com/rpc-api
+ * http://web.archive.org/web/20150119065246/http://txp.kusor.com/rpc-api
  *
  * Copyright (C) 2005-2006, 2016 The Textpattern Development Team
- * Author: Pedro Palazón - http://kusor.com
+ * Author: Pedro Palazón
  *
  * This file is part of Textpattern.
  *

--- a/rpc/index.php
+++ b/rpc/index.php
@@ -5,10 +5,10 @@
  * http://textpattern.com
  *
  * XML-RPC Server for Textpattern 4.0.x
- * http://txp.kusor.com/rpc-api
+ * http://web.archive.org/web/20150119065246/http://txp.kusor.com/rpc-api
  *
  * Copyright (C) 2005-2006, 2016 The Textpattern Development Team
- * Author: Pedro Palazón - http://kusor.com
+ * Author: Pedro Palazón
  *
  * This file is part of Textpattern.
  *

--- a/textpattern/lib/txplib_wrapper.php
+++ b/textpattern/lib/txplib_wrapper.php
@@ -32,8 +32,8 @@
  * properly. See RPC Server implementation to view an example of the required
  * files and predefined variables.
  *
- * @link      http://txp.kusor.com/wrapper
- * @author    Pedro Palazon - http://kusor.net/
+ * @link      http://web.archive.org/web/20141201035729/http://txp.kusor.com/wrapper
+ * @author    Pedro Palazón
  * @copyright 2005-2008 The Textpattern Development Team - http://textpattern.com
  */
 


### PR DESCRIPTION
Site is offline, has been for >12 months. This commit rewrites `kusor.com` links to most recent Wayback Machine grab at time of commit.

Addresses https://github.com/textpattern/textpattern/issues/695