### PR TITLE
Allow AND/OR in WHERE clause of safe_upsert (+ useless spaces deleted)

### DIFF
--- a/textpattern/lib/txplib_db.php
+++ b/textpattern/lib/txplib_db.php
@@ -394,9 +394,9 @@ function safe_query($q = '', $debug = false, $unbuf = false)
     if ($production_status !== 'live') {
         $trace->start("[SQL: $q ]", true);
     }
-    
+
     $result = mysqli_query($DB->link, $q, $method);
-    
+
     if ($production_status !== 'live') {
         $trace->stop();
     }
@@ -509,6 +509,7 @@ function safe_upsert($table, $set, $where, $debug = false)
     if ($r and (mysqli_affected_rows($DB->link) or safe_count($table, $where, $debug))) {
         return $r;
     } else {
+        $where = implode(', ', (preg_split( "/ (AND|OR) /", $where)));
         return safe_insert($table, join(', ', array($where, $set)), $debug);
     }
 }
@@ -1452,7 +1453,7 @@ eod;
  * the txp_file table.
  *
  * @param  string $type   Column name, lower case (one of 'posted', 'expires', 'created')
- * @param  bool   $update Force update 
+ * @param  bool   $update Force update
  * @return string SQL query string partial
  */
 
@@ -1478,7 +1479,7 @@ function now($type, $update = false) {
             $table = ($type === 'created') ? 'txp_file' : 'textpattern';
             $where = '1=1 having utime > '.$time.' order by utime asc limit 1';
             $now = safe_field('unix_timestamp('.$type.') as utime', $table, $where);
-            $now = ($now === false) ? 2147483647 : intval($now) - 1; 
+            $now = ($now === false) ? 2147483647 : intval($now) - 1;
             update_pref($pref, $now);
             $nows[$type] = $now;
         }


### PR DESCRIPTION
As said [here](http://forum.textpattern.com/viewtopic.php?id=47170), the following code does not work.

    safe_upsert(
        'txp_lang', 
        'data = "My data", event = "public"',
        'name = "my_data" AND lang = "en-gb"'
    )

The problem is that on `INSERT`, the `WHERE` clause is simply added to the set clause and throw that:

`[SQL: INSERT INTO txp_lang SET name = 'my_data' AND lang = 'en-gb', data = 'My data', event = 'public' ]`

…It keeps the `AND.`

I know that all `WHERE` clauses won't work with `safe_upsert` but can't we allow the use of `AND` (and `OR`?) like so (or in another better way). `OR` could work if the two columns are different.