### PR TITLE
PSR-2 coding style

### DIFF
--- a/css.php
+++ b/css.php
@@ -40,7 +40,8 @@ if (@ini_get('register_globals')) {
         (array) $_POST,
         (array) $_COOKIE,
         (array) $_FILES,
-        (array) $_SERVER);
+        (array) $_SERVER
+    );
 
     // As the deliberate awkwardly-named local variable $_txpfoo MUST NOT be
     // unset to avoid notices further down, we must remove any potential

--- a/index.php
+++ b/index.php
@@ -38,7 +38,8 @@ if (@ini_get('register_globals')) {
         (array) $_POST,
         (array) $_COOKIE,
         (array) $_FILES,
-        (array) $_SERVER);
+        (array) $_SERVER
+    );
 
     // As the deliberate awkwardly-named local variable $_txpfoo MUST NOT be
     // unset to avoid notices further down, we must remove any potential

--- a/rpc/TXP_RPCServer.php
+++ b/rpc/TXP_RPCServer.php
@@ -33,7 +33,7 @@ require_once txpath.'/lib/txplib_html.php';
 
 class TXP_RPCServer extends IXR_IntrospectionServer
 {
-    function __construct()
+    public function __construct()
     {
         global $enable_xmlrpc_server, $HTTP_RAW_POST_DATA;
 
@@ -202,7 +202,7 @@ class TXP_RPCServer extends IXR_IntrospectionServer
 
     // Override serve method in order to keep requests logs too while dealing
     // with unknown clients.
-    function serve($data = false)
+    public function serve($data = false)
     {
         if (!$data) {
             global $HTTP_RAW_POST_DATA;
@@ -215,20 +215,17 @@ class TXP_RPCServer extends IXR_IntrospectionServer
 
             $rx = '/<?xml.*encoding=[\'"](.*?)[\'"].*?>/m';
 
-            // First, handle the known UAs in order to serve proper content.
             if (strpos('w.bloggar', $_SERVER['HTTP_USER_AGENT']) !== false) {
+                // First, handle the known UAs in order to serve proper content.
                 $encoding = 'iso-8859-1';
-            }
-            // Find for supplied encoding before to try other things.
-            elseif (preg_match($rx, $HTTP_RAW_POST_DATA, $xml_enc)) {
+            } elseif (preg_match($rx, $HTTP_RAW_POST_DATA, $xml_enc)) {
+                // Find for supplied encoding before to try other things.
                 $encoding = strtolower($xml_enc[1]);
-            }
-            // Try UTF-8 detect.
-            elseif (preg_match('/^([\x00-\x7f]|[\xc2-\xdf][\x80-\xbf]|\xe0[\xa0-\xbf][\x80-\xbf]|[\xe1-\xec][\x80-\xbf]{2}|\xed[\x80-\x9f][\x80-\xbf]|[\xee-\xef][\x80-\xbf]{2}|f0[\x90-\xbf][\x80-\xbf]{2}|[\xf1-\xf3][\x80-\xbf]{3}|\xf4[\x80-\x8f][\x80-\xbf]{2})*$/', $HTTP_RAW_POST_DATA) === 1) {
+            } elseif (preg_match('/^([\x00-\x7f]|[\xc2-\xdf][\x80-\xbf]|\xe0[\xa0-\xbf][\x80-\xbf]|[\xe1-\xec][\x80-\xbf]{2}|\xed[\x80-\x9f][\x80-\xbf]|[\xee-\xef][\x80-\xbf]{2}|f0[\x90-\xbf][\x80-\xbf]{2}|[\xf1-\xf3][\x80-\xbf]{3}|\xf4[\x80-\x8f][\x80-\xbf]{2})*$/', $HTTP_RAW_POST_DATA) === 1) {
+                // Try UTF-8 detect.
                 $encoding = 'utf-8';
-            }
-            // Otherwise, use ISO-8859-1.
-            else {
+            } else {
+                // Otherwise, use ISO-8859-1.
                 $encoding = 'iso-8859-1';
             }
 
@@ -295,7 +292,7 @@ EOD;
     }
 
     // Override default UTF-8 output, if needed.
-    function output($xml, $enc = 'utf-8')
+    public function output($xml, $enc = 'utf-8')
     {
         // Be kind with non-UTF-8 capable clients.
         if ($enc != 'utf-8') {
@@ -323,7 +320,7 @@ EOD;
 //---------------------------------------------------------
 
     // Really Simple Discoverability 1.0 response.
-    function rsd()
+    public function rsd()
     {
         global $enable_xmlrpc_server;
 
@@ -338,10 +335,14 @@ EOD;
                             n.'<api name="Movable Type" blogID="" preferred="true" apiLink="'.txrpcpath.'" />'.
                             n.'<api name="MetaWeblog" blogID="" preferred="false" apiLink="'.txrpcpath.'" />'.
                             n.'<api name="Blogger" blogID="" preferred="false" apiLink="'.txrpcpath.'" />'.n,
-                            'apis').n,
-                    'service').n,
-                    'rsd', ' version="1.0" xmlns="http://archipelago.phrasewise.com/rsd"')
-                );
+                            'apis'
+                        ).n,
+                        'service'
+                    ).n,
+                    'rsd',
+                    ' version="1.0" xmlns="http://archipelago.phrasewise.com/rsd"'
+                )
+            );
         } else {
             header('Status: 501 Not Implemented');
             header('HTTP/1.1 501 Not Implemented');
@@ -352,7 +353,7 @@ EOD;
 //---------------------------------------------------------
 
     // Blogger API.
-    function blogger_newPost($params)
+    public function blogger_newPost($params)
     {
         list($appkey, $blogid, $username, $password, $content, $publish) = $params;
 
@@ -376,7 +377,7 @@ EOD;
         return intval($rs);
     }
 
-    function blogger_editPost($params)
+    public function blogger_editPost($params)
     {
         list($appkey, $postid, $username, $password, $content, $publish) = $params;
 
@@ -405,7 +406,7 @@ EOD;
         return true;
     }
 
-    function blogger_getUsersBlogs($params)
+    public function blogger_getUsersBlogs($params)
     {
         list($appkey, $username, $password) = $params;
 
@@ -436,7 +437,7 @@ EOD;
         return $sections;
     }
 
-    function blogger_getUserInfo($params)
+    public function blogger_getUserInfo($params)
     {
         list($appkey, $username, $password) = $params;
 
@@ -473,7 +474,7 @@ EOD;
         return $uinfo;
     }
 
-    function blogger_getTemplate($params)
+    public function blogger_getTemplate($params)
     {
         list($appkey, $blogid, $username, $password, $templateType) = $params;
 
@@ -504,7 +505,7 @@ EOD;
         return $rs;
     }
 
-    function blogger_setTemplate($params)
+    public function blogger_setTemplate($params)
     {
         list($appkey, $blogid, $username, $password, $template, $templateType) = $params;
 
@@ -538,7 +539,7 @@ EOD;
 //---------------------------------------------------------
 
     // Blogger 2.0.
-    function blogger_getPost($params)
+    public function blogger_getPost($params)
     {
         list($appkey, $postid, $username, $password) = $params;
 
@@ -564,7 +565,7 @@ EOD;
         return $out;
     }
 
-    function blogger_deletePost($params)
+    public function blogger_deletePost($params)
     {
         list($appkey, $postid, $username, $password, $publish) = $params;
 
@@ -584,7 +585,7 @@ EOD;
         return $rs;
     }
 
-    function blogger_getRecentPosts($params)
+    public function blogger_getRecentPosts($params)
     {
         list($appkey, $blogid, $username, $password, $numberOfPosts) = $params;
 
@@ -594,7 +595,13 @@ EOD;
             return new IXR_Error(100, gTxt('bad_login'));
         }
 
-        $articles = $txp->getArticleList('ID, Body, AuthorId, unix_timestamp(Posted) as uPosted', "Section='".doSlash($blogid)."'", '0', $numberOfPosts, false);
+        $articles = $txp->getArticleList(
+            'ID, Body, AuthorId, unix_timestamp(Posted) as uPosted',
+            "Section='".doSlash($blogid)."'",
+            '0',
+            $numberOfPosts,
+            false
+        );
 
         if (false === $articles) {
             return new IXR_Error(207, gTxt('problem_getting_articles'));
@@ -615,7 +622,7 @@ EOD;
 //---------------------------------------------------------
 
     // metaWeblog API.
-    function metaWeblog_getPost($params)
+    public function metaWeblog_getPost($params)
     {
         list($postid, $username, $password) = $params;
 
@@ -634,7 +641,7 @@ EOD;
         return $this->_buildMetaWeblogStruct($rs, $txp);
     }
 
-    function metaWeblog_newPost($params)
+    public function metaWeblog_newPost($params)
     {
         list($blogid, $username, $password, $struct, $publish) = $params;
 
@@ -658,7 +665,7 @@ EOD;
         return "$rs";
     }
 
-    function metaWeblog_editPost($params)
+    public function metaWeblog_editPost($params)
     {
         list($postid, $username, $password, $struct, $publish) = $params;
 
@@ -679,7 +686,7 @@ EOD;
         return true;
     }
 
-    function metaWeblog_getCategories($params)
+    public function metaWeblog_getCategories($params)
     {
         list($blogid, $username, $password) = $params;
 
@@ -711,7 +718,7 @@ EOD;
         return $cats;
     }
 
-    function metaWeblog_getRecentPosts($params)
+    public function metaWeblog_getRecentPosts($params)
     {
         list($blogid, $username, $password, $numberOfPosts) = $params;
 
@@ -721,8 +728,13 @@ EOD;
             return new IXR_Error(100, gTxt('bad_login'));
         }
 
-        $articles = $txp->getArticleList('ID, Title, url_title, Body, Excerpt, Annotate, Keywords, Section, Category1, Category2, textile_body, AuthorID, unix_timestamp(Posted) as uPosted',
-            "Section='".doSlash($blogid)."'", '0', $numberOfPosts, false);
+        $articles = $txp->getArticleList(
+            'ID, Title, url_title, Body, Excerpt, Annotate, Keywords, Section, Category1, Category2, textile_body, AuthorID, unix_timestamp(Posted) as uPosted',
+            "Section='".doSlash($blogid)."'",
+            '0',
+            $numberOfPosts,
+            false
+        );
 
         if (false === $articles) {
             return new IXR_Error(207, gTxt('problem_getting_articles'));
@@ -740,7 +752,7 @@ EOD;
 //---------------------------------------------------------
 
     // MovableType API.
-    function mt_getRecentPostTitles($params)
+    public function mt_getRecentPostTitles($params)
     {
         list($blogid, $username, $password, $numberOfPosts) = $params;
 
@@ -774,7 +786,7 @@ EOD;
         return $out;
     }
 
-    function mt_getCategoryList($params)
+    public function mt_getCategoryList($params)
     {
         list($blogid, $username, $password) = $params;
 
@@ -802,7 +814,7 @@ EOD;
         return $cats;
     }
 
-    function mt_supportedTextFilters($params)
+    public function mt_supportedTextFilters($params)
     {
         $filters = array(
             array('key' => '0', 'label' => 'LEAVE_TEXT_UNTOUCHED'),
@@ -813,7 +825,7 @@ EOD;
         return $filters;
     }
 
-    function mt_getPostCategories($params)
+    public function mt_getPostCategories($params)
     {
         list($postid, $username, $password) = $params;
 
@@ -858,7 +870,7 @@ EOD;
 
     // TODO: explain what 'expecific' is ;)
     // Supported to avoid some client expecific behaviour.
-    function mt_publishPost($params)
+    public function mt_publishPost($params)
     {
         list($postid, $username, $password) = $params;
 
@@ -877,7 +889,7 @@ EOD;
         return true;
     }
 
-    function mt_setPostCategories($params)
+    public function mt_setPostCategories($params)
     {
         list($postid, $username, $password, $categories) = $params;
 
@@ -928,7 +940,7 @@ EOD;
      */
 
     // Code refactoring for blogger_newPost and blogger_editPost.
-    function _getBloggerContents($content)
+    public function _getBloggerContents($content)
     {
         $body = $content;
 
@@ -950,7 +962,7 @@ EOD;
     }
 
     // Code refactoring for metaWeblog_newPost and metaweblog_EditPost.
-    function _getMetaWeblogContents($struct, $publish, $txp)
+    private function _getMetaWeblogContents($struct, $publish, $txp)
     {
         global $gmtoffset, $is_dst;
 
@@ -1030,7 +1042,7 @@ EOD;
     // Common code to metaWeblog_getPost and metaWeblog_getRecentPosts could
     // not be this placed on a different file from taghandlers?
     // Remove if it is the case.
-    function _buildMetaWeblogStruct($rs, $txp)
+    private function _buildMetaWeblogStruct($rs, $txp)
     {
         global $permlink_mode, $is_dst, $gmtoffset;
 

--- a/rpc/index.php
+++ b/rpc/index.php
@@ -44,7 +44,8 @@ if (@ini_get('register_globals')) {
         (array) $_POST,
         (array) $_COOKIE,
         (array) $_FILES,
-        (array) $_SERVER);
+        (array) $_SERVER
+    );
 
     // As the deliberate awkwardly-named local variable $_txpfoo MUST NOT be
     // unset to avoid notices further down, we must remove any potential

--- a/textpattern/admin-themes/hive/hive.php
+++ b/textpattern/admin-themes/hive/hive.php
@@ -27,7 +27,7 @@ if (!defined('txpinterface')) {
 
 class hive_theme extends \Textpattern\Admin\Theme
 {
-    function html_head()
+    public function html_head()
     {
         $cssPath = 'assets'.DS.'css';
         $jsPath = 'assets'.DS.'js';
@@ -68,7 +68,7 @@ class hive_theme extends \Textpattern\Admin\Theme
         return join(n, $out);
     }
 
-    function header()
+    public function header()
     {
         global $txp_user;
 
@@ -91,8 +91,11 @@ class hive_theme extends \Textpattern\Admin\Theme
                 $txpnavdrop++;
                 $class = ($tab['active']) ? ' selected' : '';
                 $out[] = '<li class="dropdown'.$class.'">'.
-                    n.href($tab['label'], '#',
-                    ' class="dropdown-toggle" id="txp-nav-drop'.$txpnavdrop.'" role="button" aria-controls="txp-nav-drop'.$txpnavdrop.'-menu" data-toggle="dropdown"');
+                    n.href(
+                        $tab['label'],
+                        '#',
+                        ' class="dropdown-toggle" id="txp-nav-drop'.$txpnavdrop.'" role="button" aria-controls="txp-nav-drop'.$txpnavdrop.'-menu" data-toggle="dropdown"'
+                    );
 
                 if (!empty($tab['items'])) {
                     $out[] = '<ul class="dropdown-menu" id="txp-nav-drop'.$txpnavdrop.'-menu" role="menu" aria-labelledby="txp-nav-drop'.$txpnavdrop.'">';
@@ -113,38 +116,47 @@ class hive_theme extends \Textpattern\Admin\Theme
             $out[] = '</ul>';
             $out[] = '</nav>';
             $out[] = graf(
-                href(span(htmlspecialchars($GLOBALS["prefs"]["sitename"]), array('class' => 'txp-view-site-name')), hu, array(
-                    'target' => '_blank',
-                    'title'  => gTxt('tab_view_site'),
-                )), array('class' => 'txp-view-site'));
+                href(
+                    span(htmlspecialchars($GLOBALS["prefs"]["sitename"]), array('class' => 'txp-view-site-name')),
+                    hu,
+                    array(
+                        'target' => '_blank',
+                        'title'  => gTxt('tab_view_site'),
+                    )
+                ),
+                array('class' => 'txp-view-site')
+            );
             $out[] = graf(
-                href(gTxt('logout'), 'index.php?logout=1', ' onclick="return verify(\''.gTxt('are_you_sure').'\')"'), array('class' => 'txp-logout'));
+                href(gTxt('logout'), 'index.php?logout=1', ' onclick="return verify(\''.gTxt('are_you_sure').'\')"'),
+                array('class' => 'txp-logout')
+            );
         }
 
         return join(n, $out);
     }
 
-    function footer()
+    public function footer()
     {
         $out[] = graf(
             href('Textpattern CMS', 'http://textpattern.com', array(
                 'rel'    => 'external',
                 'target' => '_blank',
                 'title'  => gTxt('go_txp_com'),
-            )).
-            ' (v'.txp_version.')', array('class' => 'mothership'));
+            )).' (v'.txp_version.')',
+            array('class' => 'mothership')
+        );
 
         $out[] = graf(href(gTxt('back_to_top'), '#'), array('class' => 'pagejump'));
 
         return join(n, $out);
     }
 
-    function announce($thing = array('', 0), $modal = false)
+    public function announce($thing = array('', 0), $modal = false)
     {
         return $this->_announce($thing, false, $modal);
     }
 
-    function announce_async($thing = array('', 0), $modal = false)
+    public function announce_async($thing = array('', 0), $modal = false)
     {
         return $this->_announce($thing, true, $modal);
     }
@@ -208,7 +220,7 @@ EOS;
         }
     }
 
-    function manifest()
+    public function manifest()
     {
         global $prefs;
 

--- a/textpattern/admin-themes/hiveneutral/hiveneutral.php
+++ b/textpattern/admin-themes/hiveneutral/hiveneutral.php
@@ -27,7 +27,7 @@ if (!defined('txpinterface')) {
 
 class hiveNeutral_theme extends \Textpattern\Admin\Theme
 {
-    function html_head()
+    public function html_head()
     {
         $cssPath = 'assets'.DS.'css';
         $jsPath = 'assets'.DS.'js';
@@ -68,7 +68,7 @@ class hiveNeutral_theme extends \Textpattern\Admin\Theme
         return join(n, $out);
     }
 
-    function header()
+    public function header()
     {
         global $txp_user;
 
@@ -91,8 +91,11 @@ class hiveNeutral_theme extends \Textpattern\Admin\Theme
                 $txpnavdrop++;
                 $class = ($tab['active']) ? ' selected' : '';
                 $out[] = '<li class="dropdown'.$class.'">'.
-                    n.href($tab['label'], '#',
-                    ' class="dropdown-toggle" id="txp-nav-drop'.$txpnavdrop.'" role="button" aria-controls="txp-nav-drop'.$txpnavdrop.'-menu" data-toggle="dropdown"');
+                    n.href(
+                        $tab['label'],
+                        '#',
+                        ' class="dropdown-toggle" id="txp-nav-drop'.$txpnavdrop.'" role="button" aria-controls="txp-nav-drop'.$txpnavdrop.'-menu" data-toggle="dropdown"'
+                    );
 
                 if (!empty($tab['items'])) {
                     $out[] = '<ul class="dropdown-menu" id="txp-nav-drop'.$txpnavdrop.'-menu" role="menu" aria-labelledby="txp-nav-drop'.$txpnavdrop.'">';
@@ -113,38 +116,47 @@ class hiveNeutral_theme extends \Textpattern\Admin\Theme
             $out[] = '</ul>';
             $out[] = '</nav>';
             $out[] = graf(
-                href(span(htmlspecialchars($GLOBALS["prefs"]["sitename"]), array('class' => 'txp-view-site-name')), hu, array(
-                    'target' => '_blank',
-                    'title'  => gTxt('tab_view_site'),
-                )), array('class' => 'txp-view-site'));
+                href(
+                    span(htmlspecialchars($GLOBALS["prefs"]["sitename"]), array('class' => 'txp-view-site-name')),
+                    hu,
+                    array(
+                        'target' => '_blank',
+                        'title'  => gTxt('tab_view_site'),
+                    )
+                ),
+                array('class' => 'txp-view-site')
+            );
             $out[] = graf(
-                href(gTxt('logout'), 'index.php?logout=1', ' onclick="return verify(\''.gTxt('are_you_sure').'\')"'), array('class' => 'txp-logout'));
+                href(gTxt('logout'), 'index.php?logout=1', ' onclick="return verify(\''.gTxt('are_you_sure').'\')"'),
+                array('class' => 'txp-logout')
+            );
         }
 
         return join(n, $out);
     }
 
-    function footer()
+    public function footer()
     {
         $out[] = graf(
             href('Textpattern CMS', 'http://textpattern.com', array(
                 'rel'    => 'external',
                 'target' => '_blank',
                 'title'  => gTxt('go_txp_com'),
-            )).
-            ' (v'.txp_version.')', array('class' => 'mothership'));
+            )).' (v'.txp_version.')',
+            array('class' => 'mothership')
+        );
 
         $out[] = graf(href(gTxt('back_to_top'), '#'), array('class' => 'pagejump'));
 
         return join(n, $out);
     }
 
-    function announce($thing = array('', 0), $modal = false)
+    public function announce($thing = array('', 0), $modal = false)
     {
         return $this->_announce($thing, false, $modal);
     }
 
-    function announce_async($thing = array('', 0), $modal = false)
+    public function announce_async($thing = array('', 0), $modal = false)
     {
         return $this->_announce($thing, true, $modal);
     }
@@ -208,7 +220,7 @@ EOS;
         }
     }
 
-    function manifest()
+    public function manifest()
     {
         global $prefs;
 

--- a/textpattern/include/txp_admin.php
+++ b/textpattern/include/txp_admin.php
@@ -230,31 +230,44 @@ function new_pass_form($message = '')
 {
     pagetop(gTxt('tab_site_admin'), $message);
 
-    echo form(
-        hed(gTxt('change_password'), 2).
-        inputLabel(
-            'current_pass',
-            fInput('password', 'current_pass', '', '', '', '', INPUT_REGULAR, '', 'current_pass'),
-            'current_password', '', array('class' => 'txp-form-field edit-admin-current-password')
-        ).
-        inputLabel(
-            'new_pass',
-            fInput('password', 'new_pass', '', 'txp-maskable txp-strength-hint', '', '', INPUT_REGULAR, '', 'new_pass').
-            n.tag(null, 'div', array('class' => 'strength-meter')).
-            n.tag(
-                checkbox('unmask', 1, false, 0, 'show_password').
-                n.tag(gTxt('show_password'), 'label', array('for' => 'show_password')),
-                'div', array('class' => 'edit-admin-show-password')),
-            'new_password', '', array('class' => 'txp-form-field edit-admin-new-password')
-        ).
-        graf(
-            sLink('admin', '', gTxt('cancel'), 'txp-button').
-            fInput('submit', 'change_pass', gTxt('submit'), 'publish'),
-            array('class' => 'txp-edit-actions')
-        ).
-        eInput('admin').
-        sInput('change_pass'),
-    '', '', 'post', 'txp-edit', '', 'change_password');
+    echo
+        form(
+            hed(gTxt('change_password'), 2).
+            inputLabel(
+                'current_pass',
+                fInput('password', 'current_pass', '', '', '', '', INPUT_REGULAR, '', 'current_pass'),
+                'current_password',
+                '',
+                array('class' => 'txp-form-field edit-admin-current-password')
+            ).
+            inputLabel(
+                'new_pass',
+                fInput('password', 'new_pass', '', 'txp-maskable txp-strength-hint', '', '', INPUT_REGULAR, '', 'new_pass').
+                n.tag(null, 'div', array('class' => 'strength-meter')).
+                n.tag(
+                    checkbox('unmask', 1, false, 0, 'show_password').
+                    n.tag(gTxt('show_password'), 'label', array('for' => 'show_password')),
+                    'div',
+                    array('class' => 'edit-admin-show-password')
+                ),
+                'new_password',
+                '',
+                array('class' => 'txp-form-field edit-admin-new-password')
+            ).
+            graf(
+                sLink('admin', '', gTxt('cancel'), 'txp-button').
+                fInput('submit', 'change_pass', gTxt('submit'), 'publish'),
+                array('class' => 'txp-edit-actions')
+            ).
+            eInput('admin').
+            sInput('change_pass'),
+            '',
+            '',
+            'post',
+            'txp-edit',
+            '',
+            'change_password'
+        );
 }
 
 /**
@@ -271,21 +284,30 @@ function change_email_form($message = '')
 
     $email = fetch('email', 'txp_users', 'name', $txp_user);
 
-    echo form(
-        hed(gTxt('change_email_address'), 2).
-        inputLabel(
-            'new_email',
-            fInput('text', 'new_email', $email, '', '', '', INPUT_REGULAR, '', 'new_email'),
-            'new_email', '', array('class' => 'txp-form-field edit-admin-new-email')
-        ).
-        graf(
-            sLink('admin', '', gTxt('cancel'), 'txp-button').
-            fInput('submit', 'change_email', gTxt('submit'), 'publish'),
-            array('class' => 'txp-edit-actions')
-        ).
-        eInput('admin').
-        sInput('change_email'),
-    '', '', 'post', 'txp-edit', '', 'change_email');
+    echo
+        form(
+            hed(gTxt('change_email_address'), 2).
+            inputLabel(
+                'new_email',
+                fInput('text', 'new_email', $email, '', '', '', INPUT_REGULAR, '', 'new_email'),
+                'new_email',
+                '',
+                array('class' => 'txp-form-field edit-admin-new-email')
+            ).
+            graf(
+                sLink('admin', '', gTxt('cancel'), 'txp-button').
+                fInput('submit', 'change_email', gTxt('submit'), 'publish'),
+                array('class' => 'txp-edit-actions')
+            ).
+            eInput('admin').
+            sInput('change_email'),
+            '',
+            '',
+            'post',
+            'txp-edit',
+            '',
+            'change_email'
+        );
 }
 
 /**
@@ -352,7 +374,8 @@ function author_list($message = '')
 
         $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
-        $search = new Filter($event,
+        $search = new Filter(
+            $event,
             array(
                 'login' => array(
                     'column' => 'txp_users.name',
@@ -386,12 +409,15 @@ function author_list($message = '')
 
         echo n.tag(
             hed(gTxt('tab_site_admin'), 1, array('class' => 'txp-heading')),
-            'div', array('class' => 'txp-layout-2col-cell-1'));
+            'div',
+            array('class' => 'txp-layout-2col-cell-1')
+        );
 
         $searchBlock =
             n.tag(
                 $search->renderForm('author_list', $search_render_options),
-                'div', array(
+                'div',
+                array(
                     'class' => 'txp-layout-2col-cell-2',
                     'id'    => 'users_control',
                 )
@@ -410,7 +436,8 @@ function author_list($message = '')
 
         if ($total < 1) {
             if ($criteria != 1) {
-                echo $searchBlock.
+                echo
+                    $searchBlock.
                     $contentBlockStart.
                     $createBlock.
                     graf(
@@ -454,29 +481,30 @@ function author_list($message = '')
                         ($use_multi_edit)
                         ? hCell(
                             fInput('checkbox', 'select_all', 0, '', '', '', '', '', 'select_all'),
-                                '', ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
+                            '',
+                            ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
                         )
                         : hCell('', '', ' class="txp-list-col-multi-edit" scope="col"')
                     ).
                     column_head(
                         'login_name', 'name', 'admin', true, $switch_dir, '', '',
-                            (('name' == $sort) ? "$dir " : '').'txp-list-col-login-name name'
+                        (('name' == $sort) ? "$dir " : '').'txp-list-col-login-name name'
                     ).
                     column_head(
                         'real_name', 'RealName', 'admin', true, $switch_dir, '', '',
-                            (('RealName' == $sort) ? "$dir " : '').'txp-list-col-real-name name'
+                        (('RealName' == $sort) ? "$dir " : '').'txp-list-col-real-name name'
                     ).
                     column_head(
                         'email', 'email', 'admin', true, $switch_dir, '', '',
-                            (('email' == $sort) ? "$dir " : '').'txp-list-col-email'
+                        (('email' == $sort) ? "$dir " : '').'txp-list-col-email'
                     ).
                     column_head(
                         'privileges', 'privs', 'admin', true, $switch_dir, '', '',
-                            (('privs' == $sort) ? "$dir " : '').'txp-list-col-privs'
+                        (('privs' == $sort) ? "$dir " : '').'txp-list-col-privs'
                     ).
                     column_head(
                         'last_login', 'last_login', 'admin', true, $switch_dir, '', '',
-                            (('last_login' == $sort) ? "$dir " : '').'txp-list-col-last-login date'
+                        (('last_login' == $sort) ? "$dir " : '').'txp-list-col-last-login date'
                     )
                 ).
                 n.tag_end('thead').
@@ -487,22 +515,28 @@ function author_list($message = '')
 
                 echo tr(
                     td(
-                        ((has_privs('admin.edit') and $txp_user != $a['name']) ? fInput('checkbox', 'selected[]', $a['name'], 'checkbox') : ''), '', 'txp-list-col-multi-edit'
+                        ((has_privs('admin.edit') and $txp_user != $a['name'])
+                        ? fInput('checkbox', 'selected[]', $a['name'], 'checkbox')
+                        : ''),
+                        '',
+                        'txp-list-col-multi-edit'
                     ).
                     hCell(
-                        ((has_privs('admin.edit')) ? eLink('admin', 'author_edit', 'user_id', $user_id, $name) : $name), '', ' class="txp-list-col-login-name name" scope="row"'
+                        ((has_privs('admin.edit'))
+                        ? eLink('admin', 'author_edit', 'user_id', $user_id, $name)
+                        : $name),
+                        '',
+                        ' class="txp-list-col-login-name name" scope="row"'
                     ).
+                    td($RealName, '', 'txp-list-col-real-name name').
+                    td(href($email, 'mailto:'.$email), '', 'txp-list-col-email').
+                    td(get_priv_level($privs), '', 'txp-list-col-privs').
                     td(
-                        $RealName, '', 'txp-list-col-real-name name'
-                    ).
-                    td(
-                        href($email, 'mailto:'.$email), '', 'txp-list-col-email'
-                    ).
-                    td(
-                        get_priv_level($privs), '', 'txp-list-col-privs'
-                    ).
-                    td(
-                        ($last_login ? safe_strftime('%b&#160;%Y', $last_login) : ''), '', 'txp-list-col-last-login date'
+                        ($last_login
+                        ? safe_strftime('%b&#160;%Y', $last_login)
+                        : ''),
+                        '',
+                        'txp-list-col-last-login date'
                     )
                 );
             }
@@ -578,38 +612,50 @@ function author_edit($message = '')
         $out[] = inputLabel(
             'login_name',
             strong(txpspecialchars($name)),
-            '', '', array('class' => 'txp-form-field edit-admin-login-name')
+            '',
+            '',
+            array('class' => 'txp-form-field edit-admin-login-name')
         );
     } else {
         $out[] = inputLabel(
             'login_name',
             fInput('text', 'name', $name, '', '', '', INPUT_REGULAR, '', 'login_name'),
-            'login_name', 'add_new_author', array('class' => 'txp-form-field edit-admin-login-name')
+            'login_name',
+            'add_new_author',
+            array('class' => 'txp-form-field edit-admin-login-name')
         );
     }
 
     $out[] = inputLabel(
-            'real_name',
-            fInput('text', 'RealName', $RealName, '', '', '', INPUT_REGULAR, '', 'real_name'),
-            'real_name', '', array('class' => 'txp-form-field edit-admin-name')
-        ).
-        inputLabel(
-            'login_email',
-            fInput('email', 'email', $email, '', '', '', INPUT_REGULAR, '', 'login_email'),
-            'email', '', array('class' => 'txp-form-field edit-admin-email')
-        );
+        'real_name',
+        fInput('text', 'RealName', $RealName, '', '', '', INPUT_REGULAR, '', 'real_name'),
+        'real_name',
+        '',
+        array('class' => 'txp-form-field edit-admin-name')
+    ).
+    inputLabel(
+        'login_email',
+        fInput('email', 'email', $email, '', '', '', INPUT_REGULAR, '', 'login_email'),
+        'email',
+        '',
+        array('class' => 'txp-form-field edit-admin-email')
+    );
 
     if ($txp_user != $name) {
         $out[] = inputLabel(
             'privileges',
             privs($privs),
-            'privileges', 'about_privileges', array('class' => 'txp-form-field edit-admin-privileges')
+            'privileges',
+            'about_privileges',
+            array('class' => 'txp-form-field edit-admin-privileges')
         );
     } else {
         $out[] = inputLabel(
             'privileges',
             strong(get_priv_level($privs)),
-            '', '', array('class' => 'txp-form-field edit-admin-privileges')
+            '',
+            '',
+            array('class' => 'txp-form-field edit-admin-privileges')
         ).
         hInput('privs', $privs);
     }
@@ -717,7 +763,6 @@ function admin_multi_edit()
 
     switch ($method) {
         case 'delete':
-
             $assign_assets = ps('assign_assets');
 
             if (!$assign_assets) {
@@ -729,20 +774,16 @@ function admin_multi_edit()
                 callback_event('authors_deleted', '', 0, $changed);
                 $msg = 'author_deleted';
             }
-
             break;
 
         case 'changeprivilege':
-
             if (change_user_group($names, ps('privs'))) {
                 $changed = $names;
                 $msg = 'author_updated';
             }
-
             break;
 
         case 'resetpassword':
-
             foreach ($names as $name) {
                 send_reset_confirmation_request($name);
                 $changed[] = $name;
@@ -752,7 +793,6 @@ function admin_multi_edit()
             break;
 
         case 'resendactivation':
-
             foreach ($names as $name) {
                 send_account_activation($name);
                 $changed[] = $name;

--- a/textpattern/include/txp_article.php
+++ b/textpattern/include/txp_article.php
@@ -167,7 +167,9 @@ function article_post()
             $when = "NOW()";
             $when_ts = time();
         } else {
-            if (!is_numeric($year) || !is_numeric($month) || !is_numeric($day) || !is_numeric($hour) || !is_numeric($minute) || !is_numeric($second)) {
+            if (!is_numeric($year) || !is_numeric($month) || !is_numeric($day) ||
+                !is_numeric($hour) || !is_numeric($minute) || !is_numeric($second)
+            ) {
                 $ts = false;
             } else {
                 $ts = strtotime($year.'-'.$month.'-'.$day.' '.$hour.':'.$minute.':'.$second);
@@ -260,8 +262,8 @@ function article_post()
         $rs = compact($vars);
         if (article_validate($rs, $msg)) {
             $ok = safe_insert(
-               'textpattern',
-               "Title           = '$Title',
+                'textpattern',
+                "Title           = '$Title',
                 Body            = '$Body',
                 Body_html       = '$Body_html',
                 Excerpt         = '$Excerpt',
@@ -332,11 +334,14 @@ function article_save()
 
     $incoming = array_map('assert_string', psa($vars));
 
-    $oldArticle = safe_row("Status, url_title, Title, textile_body, textile_excerpt,
+    $oldArticle = safe_row(
+        "Status, url_title, Title, textile_body, textile_excerpt,
         UNIX_TIMESTAMP(LastMod) AS sLastMod, LastModID,
         UNIX_TIMESTAMP(Posted) AS sPosted,
         UNIX_TIMESTAMP(Expires) AS sExpires",
-        'textpattern', "ID = ".(int) $incoming['ID']);
+        'textpattern',
+        "ID = ".(int) $incoming['ID']
+    );
 
     if (!(($oldArticle['Status'] >= STATUS_LIVE and has_privs('article.edit.published'))
         or ($oldArticle['Status'] >= STATUS_LIVE and $incoming['AuthorID'] === $txp_user and has_privs('article.edit.own.published'))
@@ -464,8 +469,9 @@ function article_save()
 
     $rs = compact($vars);
     if (article_validate($rs, $msg)) {
-        if (safe_update('textpattern',
-           "Title           = '$Title',
+        if (safe_update(
+            'textpattern',
+            "Title          = '$Title',
             Body            = '$Body',
             Body_html       = '$Body_html',
             Excerpt         = '$Excerpt',
@@ -990,7 +996,8 @@ function article_edit($message = '', $concurrent = false, $refresh_partials = fa
                     'class' => 'language-markup',
                     'dir'   => 'ltr',
                 )),
-                'pre', array('class' => 'body line-numbers')
+                'pre',
+                array('class' => 'body line-numbers')
             );
     } else {
         echo $partials['body']['html'];
@@ -1004,13 +1011,15 @@ function article_edit($message = '', $concurrent = false, $refresh_partials = fa
                 $Excerpt_html.
                 '</div>';
         } elseif ($view == 'html') {
-            echo graf(gTxt('excerpt'), array('class' => 'alert-block information')).
+            echo
+                graf(gTxt('excerpt'), array('class' => 'alert-block information')).
                 n.tag(
                     tag(str_replace(array(t), array(sp.sp.sp.sp), txpspecialchars($Excerpt_html)), 'code', array(
                         'class' => 'language-markup',
                         'dir'   => 'ltr',
                     )),
-                    'pre', array('class' => 'excerpt line-numbers')
+                    'pre',
+                    array('class' => 'excerpt line-numbers')
                 );
         } else {
             echo $partials['excerpt']['html'];
@@ -1018,7 +1027,7 @@ function article_edit($message = '', $concurrent = false, $refresh_partials = fa
     }
 
     echo hInput('from_view', $view),
-        n.'</div>';
+         n.'</div>';
 
     // Author.
     if ($view == "text" && $step != "create") {
@@ -1026,7 +1035,7 @@ function article_edit($message = '', $concurrent = false, $refresh_partials = fa
     }
 
     echo n.'</div>'.// End of #main_content.
-        n.'</div>'; // End of .txp-layout-4col-cell-1-2-3.
+         n.'</div>'; // End of .txp-layout-4col-cell-1-2-3.
 
     // Sidebar column (only shown if in text editing view).
     if ($view == 'text') {
@@ -1041,8 +1050,7 @@ function article_edit($message = '', $concurrent = false, $refresh_partials = fa
             }
 
             echo graf($push_button, array('class' => 'txp-save'));
-        } elseif (
-            ($Status >= STATUS_LIVE && has_privs('article.edit.published')) ||
+        } elseif (($Status >= STATUS_LIVE && has_privs('article.edit.published')) ||
             ($Status >= STATUS_LIVE && $AuthorID === $txp_user && has_privs('article.edit.own.published')) ||
             ($Status < STATUS_LIVE && has_privs('article.edit')) ||
             ($Status < STATUS_LIVE && $AuthorID === $txp_user && has_privs('article.edit.own'))
@@ -1065,12 +1073,13 @@ function article_edit($message = '', $concurrent = false, $refresh_partials = fa
         echo n.'<div role="region" id="supporting_content">';
 
         // 'Sort and display' section.
-        echo pluggable_ui(
-            'article_ui',
-            'sort_display',
-            wrapRegion('txp-write-sort-group', $partials['status']['html'].$partials['section']['html'].$partials['categories']['html'], '', gTxt('sort_display')),
-            $rs
-        );
+        echo
+            pluggable_ui(
+                'article_ui',
+                'sort_display',
+                wrapRegion('txp-write-sort-group', $partials['status']['html'].$partials['section']['html'].$partials['categories']['html'], '', gTxt('sort_display')),
+                $rs
+            );
 
         // 'Date and time' collapsible section.
 
@@ -1115,7 +1124,8 @@ function article_edit($message = '', $concurrent = false, $refresh_partials = fa
                 n.tag(
                     checkbox('publish_now', '1', $publish_now, '', 'publish_now').
                     n.tag(gTxt('set_to_now'), 'label', array('for' => 'publish_now')),
-                    'div', array('class' => 'posted-now')
+                    'div',
+                    array('class' => 'posted-now')
                 ),
                 array('sPosted' => $persist_timestamp) + $rs
             );
@@ -1166,7 +1176,14 @@ function article_edit($message = '', $concurrent = false, $refresh_partials = fa
             $expires_block = $partials['expires']['html'];
         }
 
-        echo wrapRegion('txp-dates-group', $posted_block.$expires_block, 'txp-dates-group-content', 'date_settings', 'article_dates');
+        echo
+            wrapRegion(
+                'txp-dates-group',
+                $posted_block.$expires_block,
+                'txp-dates-group-content',
+                'date_settings',
+                'article_dates'
+            );
 
         // 'Meta' collapsible section.
 
@@ -1179,16 +1196,44 @@ function article_edit($message = '', $concurrent = false, $refresh_partials = fa
         // 'Keywords' field.
         $html_keywords = $partials['keywords']['html'];
 
-        echo wrapRegion('txp-meta-group', $html_url_title.$html_description.$html_keywords, 'txp-meta-group-content', 'meta', 'article_meta');
+        echo
+            wrapRegion(
+                'txp-meta-group',
+                $html_url_title.$html_description.$html_keywords,
+                'txp-meta-group-content',
+                'meta',
+                'article_meta'
+            );
 
         // 'Comment options' collapsible section.
-        echo wrapRegion('txp-comments-group', $partials['comments']['html'], 'txp-comments-group-content', 'comment_settings', 'article_comments');
+        echo
+            wrapRegion(
+                'txp-comments-group',
+                $partials['comments']['html'],
+                'txp-comments-group-content',
+                'comment_settings',
+                'article_comments'
+            );
 
         // 'Article image' collapsible section.
-        echo wrapRegion('txp-image-group', $partials['image']['html'], 'txp-image-group-content', 'article_image', 'article_image');
+        echo
+            wrapRegion(
+                'txp-image-group',
+                $partials['image']['html'],
+                'txp-image-group-content',
+                'article_image',
+                'article_image'
+            );
 
         // 'Custom fields' collapsible section.
-        echo wrapRegion('txp-custom-field-group', $partials['custom_fields']['html'], 'txp-custom-field-group-content', 'custom', 'article_custom_field');
+        echo
+            wrapRegion(
+                'txp-custom-field-group',
+                $partials['custom_fields']['html'],
+                'txp-custom-field-group-content',
+                'custom',
+                'article_custom_field'
+            );
 
         // 'Advanced options' collapsible section.
 
@@ -1218,7 +1263,9 @@ function article_edit($message = '', $concurrent = false, $refresh_partials = fa
         // 'Override form' selection.
         $form_pop = $allow_form_override ? form_pop($override_form, 'override-form') : '';
         $html_override = $form_pop
-            ? pluggable_ui('article_ui', 'override',
+            ? pluggable_ui(
+                'article_ui',
+                'override',
                 inputLabel(
                     'override-form',
                     $form_pop,
@@ -1226,19 +1273,38 @@ function article_edit($message = '', $concurrent = false, $refresh_partials = fa
                     array('override_form', 'instructions_override_form'),
                     array('class' => 'txp-form-field override-form')
                 ),
-                $rs)
+                $rs
+            )
             : '';
 
-        echo wrapRegion('txp-advanced-group', $html_markup.$html_override, 'txp-advanced-group-content', 'advanced_options', 'article_advanced');
+        echo wrapRegion(
+            'txp-advanced-group',
+            $html_markup.$html_override,
+            'txp-advanced-group-content',
+            'advanced_options',
+            'article_advanced'
+        );
 
         // Custom menu entries.
         echo pluggable_ui('article_ui', 'extend_col_1', '', $rs);
 
         // 'Text formatting help' collapsible section.
-        echo wrapRegion('txp-textfilter-group', $partials['sidehelp']['html'], 'txp-textfilter-group-content', 'textfilter_help', 'article_textfilter_help');
+        echo wrapRegion(
+            'txp-textfilter-group',
+            $partials['sidehelp']['html'],
+            'txp-textfilter-group-content',
+            'textfilter_help',
+            'article_textfilter_help'
+        );
 
         // 'Recent articles' collapsible section.
-        echo wrapRegion('txp-recent-group', $partials['recent_articles']['html'], 'txp-recent-group-content', 'recent_articles', 'article_recent');
+        echo wrapRegion(
+            'txp-recent-group',
+            $partials['recent_articles']['html'],
+            'txp-recent-group-content',
+            'recent_articles',
+            'article_recent'
+        );
 
         echo n.'</div>'; // End of #supporting_content.
 
@@ -1281,14 +1347,21 @@ function custField($num, $field, $content)
 function checkIfNeighbour($whichway, $sPosted, $ID = 0)
 {
     // Eventual backward compatibility.
-    if(empty($ID)) $ID = !empty($GLOBALS['ID']) ? $GLOBALS['ID'] : gps('ID');
+    if (empty($ID)) {
+        $ID = !empty($GLOBALS['ID']);
+    } else {
+        $GLOBALS['ID'] : gps('ID');
+    }
     $sPosted = assert_int($sPosted);
     $ID = assert_int($ID);
     $dir = ($whichway == 'prev') ? '<' : '>';
     $ord = ($whichway == 'prev') ? "DESC" : "ASC";
 
-    return safe_field("ID", 'textpattern',
-        "Posted $dir FROM_UNIXTIME($sPosted) OR Posted = FROM_UNIXTIME($sPosted) AND ID $dir $ID ORDER BY Posted $ord, ID $ord LIMIT 1");
+    return safe_field(
+        "ID",
+        'textpattern',
+        "Posted $dir FROM_UNIXTIME($sPosted) OR Posted = FROM_UNIXTIME($sPosted) AND ID $dir $ID ORDER BY Posted $ord, ID $ord LIMIT 1"
+    );
 }
 
 /**
@@ -1622,7 +1695,7 @@ function article_partial_custom_field($rs, $key)
     $custom_x_set = "custom_{$m[1]}_set";
     $custom_x = "custom_{$m[1]}";
 
-    return ($$custom_x_set !== '' ? custField($m[1], $$custom_x_set,  $rs[$custom_x]) : '');
+    return ($$custom_x_set !== '' ? custField($m[1], $$custom_x_set, $rs[$custom_x]) : '');
 }
 
 /**
@@ -1972,7 +2045,11 @@ function article_partial_article_nav($rs)
 
 function article_partial_status($rs)
 {
-    return n.tag(pluggable_ui('article_ui', 'status', status_display($rs['Status']), $rs), 'div', array('id' => 'txp-container-status'));
+    return n.tag(
+        pluggable_ui('article_ui', 'status', status_display($rs['Status']), $rs),
+        'div',
+        array('id' => 'txp-container-status')
+    );
 }
 
 /**
@@ -2079,16 +2156,17 @@ function article_partial_comments($rs)
             ));
         } else {
             $invite = n.tag(
-                    onoffRadio('Annotate', $Annotate),
-                    'div', array('class' => 'txp-form-field comment-annotate')
-                ).
-                inputLabel(
-                    'comment-invite',
-                    fInput('text', 'AnnotateInvite', $AnnotateInvite, '', '', '', INPUT_REGULAR, '', 'comment-invite'),
-                    'comment_invitation',
-                    array('', 'instructions_comment_invitation'),
-                    array('class' => 'txp-form-field comment-invite')
-                );
+                onoffRadio('Annotate', $Annotate),
+                'div',
+                array('class' => 'txp-form-field comment-annotate')
+            ).
+            inputLabel(
+                'comment-invite',
+                fInput('text', 'AnnotateInvite', $AnnotateInvite, '', '', '', INPUT_REGULAR, '', 'comment-invite'),
+                'comment_invitation',
+                array('', 'instructions_comment_invitation'),
+                array('class' => 'txp-form-field comment-invite')
+            );
         }
 
         return n.tag_start('div', array('id' => 'write-comments')).
@@ -2137,7 +2215,8 @@ function article_partial_posted($rs)
         n.tag(
             checkbox('reset_time', '1', $reset_time, '', 'reset_time').
             n.tag(gTxt('reset_time'), 'label', array('for' => 'reset_time')),
-            'div', array('class' => 'reset-time')
+            'div',
+            array('class' => 'reset-time')
         );
 
     return n.tag_start('div', array('id' => 'publish-datetime-group')).

--- a/textpattern/include/txp_auth.php
+++ b/textpattern/include/txp_auth.php
@@ -53,12 +53,11 @@ function doAuth()
     if (!$txp_user) {
         if (trim(ps('app_mode')) == 'async') {
             echo script_js(
-                'alert("'.escape_js(gTxt('login_to_textpattern')).'"); 
+                'alert("'.escape_js(gTxt('login_to_textpattern')).'");
                 window.location.assign("index.php")'
             );
             exit();
-        }
-        else {
+        } else {
             doLoginForm($message);
         }
     }
@@ -107,13 +106,16 @@ function doLoginForm($message)
             inputLabel(
                 'login_name',
                 fInput('text', 'p_userid', $name, '', '', '', INPUT_REGULAR, '', 'login_name'),
-                'name', '', array('class' => 'txp-form-field login-name')
+                'name',
+                '',
+                array('class' => 'txp-form-field login-name')
             ).
             graf(
                 fInput('submit', '', gTxt('password_reset_button'), 'publish')
             ).
             graf(
-                href(gTxt('back_to_login'), 'index.php'), array('class' => 'login-return')
+                href(gTxt('back_to_login'), 'index.php'),
+                array('class' => 'login-return')
             ).
             hInput('p_reset', 1);
     } elseif ($confirm || $activate) {
@@ -128,14 +130,19 @@ function doLoginForm($message)
                 n.tag(
                     checkbox('unmask', 1, false, 0, 'show_password').
                     n.tag(gTxt('show_password'), 'label', array('for' => 'show_password')),
-                    'div', array('class' => 'show-password')),
-                'new_password', '', array('class' => 'txp-form-field '.$class)
+                    'div',
+                    array('class' => 'show-password')
+                ),
+                'new_password',
+                '',
+                array('class' => 'txp-form-field '.$class)
             ).
             graf(
                 fInput('submit', '', gTxt('password_confirm_button'), 'publish')
             ).
             graf(
-                href(gTxt('back_to_login'), 'index.php'), array('class' => 'login-return')
+                href(gTxt('back_to_login'), 'index.php'),
+                array('class' => 'login-return')
             ).
             hInput('hash', gps('confirm').gps('activate')).
             hInput(($confirm ? 'p_alter' : 'p_set'), 1);
@@ -145,23 +152,29 @@ function doLoginForm($message)
             inputLabel(
                 'login_name',
                 fInput('text', 'p_userid', $name, '', '', '', INPUT_REGULAR, '', 'login_name'),
-                'name', '', array('class' => 'txp-form-field login-name')
+                'name',
+                '',
+                array('class' => 'txp-form-field login-name')
             ).
             inputLabel(
                 'login_password',
                 fInput('password', 'p_password', '', '', '', '', INPUT_REGULAR, '', 'login_password'),
-                'password', '', array('class' => 'txp-form-field login-password')
+                'password',
+                '',
+                array('class' => 'txp-form-field login-password')
             ).
             graf(
                 checkbox('stay', 1, $stay, '', 'login_stay').n.
                 tag(gTxt('stay_logged_in'), 'label', array('for' => 'login_stay')).
-                popHelp('remember_login'), array('class' => 'login-stay')
+                popHelp('remember_login'),
+                array('class' => 'login-stay')
             ).
             graf(
                 fInput('submit', '', gTxt('log_in_button'), 'publish')
             ).
             graf(
-                href(gTxt('password_forgotten'), '?reset=1'), array('class' => 'login-forgot')
+                href(gTxt('password_forgotten'), '?reset=1'),
+                array('class' => 'login-forgot')
             );
 
         if (gps('event')) {
@@ -171,17 +184,17 @@ function doLoginForm($message)
 
     pagetop($pageTitle, $message);
 
-    gTxtScript(array(
-        'password_strength_0',
-        'password_strength_1',
-        'password_strength_2',
-        'password_strength_3',
-        'password_strength_4',
+    gTxtScript(
+        array(
+            'password_strength_0',
+            'password_strength_1',
+            'password_strength_2',
+            'password_strength_3',
+            'password_strength_4',
         )
     );
 
-    echo form(
-        join('', $out), '', '', 'post', 'txp-login', '', 'login_form').
+    echo form(join('', $out), '', '', 'post', 'txp-login', '', 'login_form').
 
     script_js('vendors/dropbox/zxcvbn/zxcvbn.js', TEXTPATTERN_SCRIPT_URL).
     script_js('textpattern.textarray = '.json_encode($textarray_script)).

--- a/textpattern/include/txp_category.php
+++ b/textpattern/include/txp_category.php
@@ -70,25 +70,21 @@ function cat_category_list($message = "")
     pagetop(gTxt('categories'), $message);
     $out = array(hed(gTxt('tab_organise'), 1, 'class="txp-heading"'),
         n.tag(cat_article_list(), 'section', array(
-                'class' => 'txp-layout-4col-cell-1',
-                'id'    => 'categories_article',
-            )
-        ),
+            'class' => 'txp-layout-4col-cell-1',
+            'id'    => 'categories_article',
+        )),
         n.tag(cat_image_list(), 'section', array(
                 'class' => 'txp-layout-4col-cell-2',
                 'id'    => 'categories_image',
-            )
-        ),
+        )),
         n.tag(cat_file_list(), 'section', array(
-                'class' => 'txp-layout-4col-cell-3',
-                'id'    => 'categories_file',
-            )
-        ),
+            'class' => 'txp-layout-4col-cell-3',
+            'id'    => 'categories_file',
+        )),
         n.tag(cat_link_list(), 'section', array(
-                'class' => 'txp-layout-4col-cell-4',
-                'id'    => 'categories_link',
-            )
-        ),
+            'class' => 'txp-layout-4col-cell-4',
+            'id'    => 'categories_link',
+        )),
         script_js(<<<EOS
             $(document).ready(function ()
             {
@@ -259,7 +255,13 @@ function cat_article_multiedit_form($area, $array)
             form(
                 join('', $array).
                 hInput('type', $area).
-                multi_edit($methods, 'category', 'cat_category_multiedit', '', '', '', '', '', $area), '', '', 'post', 'category-tree', '', 'category_'.$area.'_form'
+                multi_edit($methods, 'category', 'cat_category_multiedit', '', '', '', '', '', $area),
+                '',
+                '',
+                'post',
+                'category-tree',
+                '',
+                'category_'.$area.'_form'
             );
     }
 
@@ -383,7 +385,12 @@ function cat_event_category_list($event)
                 fInput('submit', '', gTxt('Create')).
                 eInput('category').
                 sInput('cat_'.$event.'_create')
-            ), '', '', 'post', $event);
+            ),
+            '',
+            '',
+            'post',
+            $event
+        );
 
     if ($rs) {
         $total_count = array();
@@ -395,7 +402,8 @@ function cat_event_category_list($event)
                     SELECT ID, Category1 AS category FROM ".safe_pfx('textpattern')."
                         UNION
                     SELECT ID, Category2 AS category FROM ".safe_pfx('textpattern')."
-                ) AS t WHERE category != '' GROUP BY category");
+                ) AS t WHERE category != '' GROUP BY category"
+            );
 
             if ($rs2 !== false) {
                 foreach ($rs2 as $a) {
@@ -453,7 +461,9 @@ function cat_event_category_list($event)
             }
 
             $items[] = graf(
-                checkbox('selected[]', $id, 0).sp.str_repeat(sp.sp, $level * 2).$edit_link.sp.$count, ' class="level-'.$level.'"');
+                checkbox('selected[]', $id, 0).sp.str_repeat(sp.sp, $level * 2).$edit_link.sp.$count,
+                ' class="level-'.$level.'"'
+            );
         }
 
         if ($items) {
@@ -535,22 +545,30 @@ function cat_event_category_edit($evname, $message = '')
             inputLabel(
                 'category_name',
                 fInput('text', 'name', $name, '', '', '', INPUT_REGULAR, '', 'category_name'),
-                $evname.'_category_name', '', array('class' => 'txp-form-field edit-category-name')
+                $evname.'_category_name',
+                '',
+                array('class' => 'txp-form-field edit-category-name')
             ).
             inputLabel(
                 'category_parent',
                 $parent_widget,
-                'parent', '', array('class' => 'txp-form-field edit-category-parent')
+                'parent',
+                '',
+                array('class' => 'txp-form-field edit-category-parent')
             ).
             inputLabel(
                 'category_title',
                 fInput('text', 'title', $title, '', '', '', INPUT_REGULAR, '', 'category_title'),
-                $evname.'_category_title', '', array('class' => 'txp-form-field edit-category-title')
+                $evname.'_category_title',
+                '',
+                array('class' => 'txp-form-field edit-category-title')
             ).
             inputLabel(
                 'category_description',
                 '<textarea id="category_description" name="description" cols="'.INPUT_LARGE.'" rows="'.TEXTAREA_HEIGHT_SMALL.'">'.$description.'</textarea>',
-                $evname.'_category_description', 'category_description', array('class' => 'txp-form-field txp-form-field-textarea edit-category-description')
+                $evname.'_category_description',
+                'category_description',
+                array('class' => 'txp-form-field txp-form-field-textarea edit-category-description')
             ).
             pluggable_ui('category_ui', 'extend_detail_form', '', $row).
             hInput('id', $id).

--- a/textpattern/include/txp_css.php
+++ b/textpattern/include/txp_css.php
@@ -166,8 +166,16 @@ function css_edit($message = '')
                 'css_code',
                 array('', 'instructions_style_code'),
                 array('class' => 'txp-form-field')
-            ), '', '', 'post', '', '', 'style_form'),
-        'div', array(
+            ),
+            '',
+            '',
+            'post',
+            '',
+            '',
+            'style_form'
+        ),
+        'div',
+        array(
             'class' => 'txp-layout-4col-cell-1-2-3',
             'id'    => 'main_content',
             'role'  => 'region',
@@ -192,7 +200,8 @@ function css_edit($message = '')
             'method' => 'post',
             'value'  =>  gTxt('save'),
             'form'   => 'style_form',
-        )), ' class="txp-save"'
+        )),
+        ' class="txp-save"'
     ).
     graf(
         sLink('css', 'pour', '<span class="ui-icon ui-extra-icon-new-document"></span> '.gTxt('create_new_css'), 'txp-new').
@@ -203,7 +212,8 @@ function css_edit($message = '')
     echo n.tag(
         $buttons.
         css_list($name, $default_name).n,
-        'div', array(
+        'div',
+        array(
             'class' => 'txp-layout-4col-cell-4alt',
             'id'    => 'content_switcher',
             'role'  => 'region',

--- a/textpattern/include/txp_discuss.php
+++ b/textpattern/include/txp_discuss.php
@@ -78,7 +78,8 @@ function discuss_save()
     callback_event_ref('discuss_ui', 'validate_save', 0, $varray, $constraints);
     $validator = new Validator($constraints);
 
-    if ($validator->validate() && safe_update('txp_discuss',
+    if ($validator->validate() && safe_update(
+        'txp_discuss',
         "email   = '$email',
          name    = '$name',
          web     = '$web',
@@ -185,7 +186,8 @@ function discuss_list($message = '')
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
-    $search = new Filter($event,
+    $search = new Filter(
+        $event,
         array(
             'id' => array(
                 'column' => 'txp_discuss.discussid',
@@ -267,12 +269,15 @@ function discuss_list($message = '')
 
     echo n.tag(
         hed(gTxt('list_discussions'), 1, array('class' => 'txp-heading')),
-        'div', array('class' => 'txp-layout-2col-cell-1'));
+        'div',
+        array('class' => 'txp-layout-2col-cell-1')
+    );
 
     $searchBlock =
         n.tag(
             $search->renderForm('discuss_list', $search_render_options),
-            'div', array(
+            'div',
+            array(
                 'class' => 'txp-layout-2col-cell-2',
                 'id'    => $event.'_control',
             )
@@ -340,10 +345,13 @@ function discuss_list($message = '')
     );
 
     if ($rs) {
-        echo n.tag(
+        echo
+            n.tag(
                 cookie_box('show_spam').
                 toggle_box('discuss_detail'),
-                'div', array('class' => 'txp-list-options')).
+                'div',
+                array('class' => 'txp-list-options')
+            ).
             n.tag_start('form', array(
                 'class'  => 'multi_edit_form',
                 'id'     => 'discuss_form',
@@ -357,43 +365,44 @@ function discuss_list($message = '')
             tr(
                 hCell(
                     fInput('checkbox', 'select_all', 0, '', '', '', '', '', 'select_all'),
-                        '', ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
+                    '',
+                    ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
                 ).
                 column_head(
                     'ID', 'id', 'discuss', true, $switch_dir, $crit, $search_method,
-                        (('id' == $sort) ? "$dir " : '').'txp-list-col-id'
+                    (('id' == $sort) ? "$dir " : '').'txp-list-col-id'
                 ).
                 column_head(
                     'date', 'date', 'discuss', true, $switch_dir, $crit, $search_method,
-                        (('date' == $sort) ? "$dir " : '').'txp-list-col-created date'
+                    (('date' == $sort) ? "$dir " : '').'txp-list-col-created date'
                 ).
                 column_head(
                     'name', 'name', 'discuss', true, $switch_dir, $crit, $search_method,
-                        (('name' == $sort) ? "$dir " : '').'txp-list-col-name'
+                    (('name' == $sort) ? "$dir " : '').'txp-list-col-name'
                 ).
                 column_head(
                     'message', 'message', 'discuss', true, $switch_dir, $crit, $search_method,
-                        (('message' == $sort) ? "$dir " : 'txp-list-col-message')
+                    (('message' == $sort) ? "$dir " : 'txp-list-col-message')
                 ).
                 column_head(
                     'email', 'email', 'discuss', true, $switch_dir, $crit, $search_method,
-                        (('email' == $sort) ? "$dir " : '').'txp-list-col-email discuss_detail'
+                    (('email' == $sort) ? "$dir " : '').'txp-list-col-email discuss_detail'
                 ).
                 column_head(
                     'website', 'website', 'discuss', true, $switch_dir, $crit, $search_method,
-                        (('website' == $sort) ? "$dir " : '').'txp-list-col-website discuss_detail'
+                    (('website' == $sort) ? "$dir " : '').'txp-list-col-website discuss_detail'
                 ).
                 column_head(
                     'IP', 'ip', 'discuss', true, $switch_dir, $crit, $search_method,
-                        (('ip' == $sort) ? "$dir " : '').'txp-list-col-ip discuss_detail'
+                    (('ip' == $sort) ? "$dir " : '').'txp-list-col-ip discuss_detail'
                 ).
                 column_head(
                     'status', 'status', 'discuss', true, $switch_dir, $crit, $search_method,
-                        (('status' == $sort) ? "$dir " : '').'txp-list-col-status'
+                    (('status' == $sort) ? "$dir " : '').'txp-list-col-status'
                 ).
                 column_head(
                     'parent', 'parent', 'discuss', true, $switch_dir, $crit, $search_method,
-                        (('parent' == $sort) ? "$dir " : '').'txp-list-col-parent'
+                    (('parent' == $sort) ? "$dir " : '').'txp-list-col-parent'
                 )
             ).
             n.tag_end('thead');
@@ -452,39 +461,28 @@ function discuss_list($message = '')
             }
 
             echo tr(
-                td(
-                    fInput('checkbox', 'selected[]', $discussid), '', 'txp-list-col-multi-edit'
-                ).
+                td(fInput('checkbox', 'selected[]', $discussid), '', 'txp-list-col-multi-edit').
                 hCell(
-                    href($discussid, $edit_url, ' title="'.gTxt('edit').'"'), '', ' class="txp-list-col-id" scope="row"'
+                    href($discussid, $edit_url, ' title="'.gTxt('edit').'"'),
+                    '',
+                    ' class="txp-list-col-id" scope="row"'
                 ).
-                td(
-                    gTime($uPosted), '', 'txp-list-col-created date'
-                ).
-                td(
-                    txpspecialchars(soft_wrap($name, 15)), '', 'txp-list-col-name'
-                ).
-                td(
-                    short_preview($dmessage), '', 'txp-list-col-message'
-                ).
-                td(
-                    txpspecialchars(soft_wrap($email, 15)), '', 'txp-list-col-email discuss_detail'
-                ).
-                td(
-                    txpspecialchars(soft_wrap($web, 15)), '', 'txp-list-col-website discuss_detail'
-                ).
+                td(gTime($uPosted), '', 'txp-list-col-created date').
+                td(txpspecialchars(soft_wrap($name, 15)), '', 'txp-list-col-name').
+                td(short_preview($dmessage), '', 'txp-list-col-message').
+                td(txpspecialchars(soft_wrap($email, 15)), '', 'txp-list-col-email discuss_detail').
+                td(txpspecialchars(soft_wrap($web, 15)), '', 'txp-list-col-website discuss_detail').
                 td(
                     href(txpspecialchars($ip), 'https://whois.domaintools.com/'.rawurlencode($ip), array(
                         'rel'    => 'external',
                         'target' => '_blank',
-                    )), '', 'txp-list-col-ip discuss_detail'
+                    )),
+                    '',
+                    'txp-list-col-ip discuss_detail'
                 ).
-                td(
-                    $view, '', 'txp-list-col-status'
-                ).
-                td(
-                    $parent, '', 'txp-list-col-parent'
-                ), ' class="'.$row_class.'"'
+                td($view, '', 'txp-list-col-status').
+                td($parent, '', 'txp-list-col-parent'),
+                ' class="'.$row_class.'"'
             );
         }
 
@@ -492,7 +490,8 @@ function discuss_list($message = '')
             echo n.tr(tda(gTxt('just_spam_results_found'), ' colspan="10"'));
         }
 
-        echo n.tag_end('tbody').
+        echo
+            n.tag_end('tbody').
             n.tag_end('table').
             n.tag_end('div').
             discuss_multiedit_form($page, $sort, $dir, $crit, $search_method).
@@ -548,19 +547,25 @@ function discuss_edit()
             $visible,
             false,
             '',
-            'status');
+            'status'
+        );
 
-        echo form(
+        echo
+            form(
                 hed(gTxt('edit_comment'), 2).
                 inputLabel(
                     'status',
                     $status_list,
-                    'status', '', array('class' => 'txp-form-field edit-comment-status')
+                    'status',
+                    '',
+                    array('class' => 'txp-form-field edit-comment-status')
                 ).
                 inputLabel(
                     'name',
                     fInput('text', 'name', $name, '', '', '', INPUT_REGULAR, '', 'name'),
-                    'name', '', array('class' => 'txp-form-field edit-comment-name')
+                    'name',
+                    '',
+                    array('class' => 'txp-form-field edit-comment-name')
                 ).
                 inputLabel(
                     'IP',
@@ -568,28 +573,37 @@ function discuss_edit()
                         'rel'    => 'external',
                         'target' => '_blank',
                     )),
-                    '', '', array('class' => 'txp-form-field edit-comment-ip')
+                    '',
+                    '',
+                    array('class' => 'txp-form-field edit-comment-ip')
                 ).
                 inputLabel(
                     'email',
                     fInput('email', 'email', $email, '', '', '', INPUT_REGULAR, '', 'email'),
-                    'email', '', array('class' => 'txp-form-field edit-comment-email')
+                    'email',
+                    '',
+                    array('class' => 'txp-form-field edit-comment-email')
                 ).
                 inputLabel(
                     'website',
                     fInput('text', 'web', $web, '', '', '', INPUT_REGULAR, '', 'website'),
-                    'website', '', array('class' => 'txp-form-field edit-comment-website')
+                    'website',
+                    '',
+                    array('class' => 'txp-form-field edit-comment-website')
                 ).
                 inputLabel(
                     'date',
-                    safe_strftime('%d %b %Y %X',
-                    $uPosted),
-                    '', '', array('class' => 'txp-form-field edit-comment-date')
+                    safe_strftime('%d %b %Y %X', $uPosted),
+                    '',
+                    '',
+                    array('class' => 'txp-form-field edit-comment-date')
                 ).
                 inputLabel(
                     'commentmessage',
                     '<textarea id="commentmessage" name="message" cols="'.INPUT_LARGE.'" rows="'.TEXTAREA_HEIGHT_MEDIUM.'">'.$message.'</textarea>',
-                    'message', '', array('class' => 'txp-form-field txp-form-field-textarea edit-comment-message')
+                    'message',
+                    '',
+                    array('class' => 'txp-form-field txp-form-field-textarea edit-comment-message')
                 ).
                 graf(
                     sLink('discuss', '', gTxt('cancel'), 'txp-button').
@@ -606,7 +620,13 @@ function discuss_edit()
                 hInput('ip', $ip).
                 eInput('discuss').
                 sInput('discuss_save'),
-            '', '', 'post', 'txp-edit', '', 'discuss_edit_form');
+                '',
+                '',
+                'post',
+                'txp-edit',
+                '',
+                'discuss_edit_form'
+            );
     } else {
         echo graf(
             span(null, array('class' => 'ui-icon ui-icon-info')).' '.
@@ -669,24 +689,15 @@ function discuss_multi_edit()
 
                 callback_event('discuss_deleted', '', 0, $done);
             } elseif ($method == 'spam') {
-                if (safe_update('txp_discuss',
-                    "visible = ".SPAM,
-                    "discussid = $id"
-                )) {
+                if (safe_update('txp_discuss', "visible = ".SPAM, "discussid = $id")) {
                     $done[] = $id;
                 }
             } elseif ($method == 'unmoderated') {
-                if (safe_update('txp_discuss',
-                    "visible = ".MODERATE,
-                    "discussid = $id"
-                )) {
+                if (safe_update('txp_discuss', "visible = ".MODERATE, "discussid = $id")) {
                     $done[] = $id;
                 }
             } elseif ($method == 'visible') {
-                if (safe_update('txp_discuss',
-                    "visible = ".VISIBLE,
-                    "discussid = $id"
-                )) {
+                if (safe_update('txp_discuss', "visible = ".VISIBLE, "discussid = $id")) {
                     $done[] = $id;
                 }
             }

--- a/textpattern/include/txp_file.php
+++ b/textpattern/include/txp_file.php
@@ -139,7 +139,8 @@ function file_list($message = '')
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
-    $search = new Filter($event,
+    $search = new Filter(
+        $event,
         array(
             'id' => array(
                 'column' => 'txp_file.id',
@@ -197,16 +198,15 @@ function file_list($message = '')
 
     echo n.tag(
         hed(gTxt('tab_file'), 1, array('class' => 'txp-heading')),
-        'div', array('class' => 'txp-layout-2col-cell-1'));
+        'div',
+        array('class' => 'txp-layout-2col-cell-1')
+    );
 
     $searchBlock =
-        n.tag(
-            $search->renderForm('file_list', $search_render_options),
-            'div', array(
+        n.tag($search->renderForm('file_list', $search_render_options), 'div', array(
                 'class' => 'txp-layout-2col-cell-2',
                 'id'    => $event.'_control',
-            )
-        );
+        ));
 
     $createBlock = array();
 
@@ -225,14 +225,19 @@ function file_list($message = '')
         $existing_files = get_filenames();
 
         if ($existing_files) {
-            $createBlock[] =
-                form(
-                    eInput('file').
-                    sInput('file_create').
-                    tag(gTxt('existing_file'), 'label', array('for' => 'file-existing')).
-                    selectInput('filename', $existing_files, '', 1, '', 'file-existing').
-                    fInput('submit', '', gTxt('Create')),
-                '', '', 'post', 'assign-existing-form', '', 'assign_file');
+            $createBlock[] = form(
+                eInput('file').
+                sInput('file_create').
+                tag(gTxt('existing_file'), 'label', array('for' => 'file-existing')).
+                selectInput('filename', $existing_files, '', 1, '', 'file-existing').
+                fInput('submit', '', gTxt('Create')),
+                '',
+                '',
+                'post',
+                'assign-existing-form',
+                '',
+                'assign_file'
+            );
         }
 
         $createBlock[] = tag_end('div');
@@ -295,8 +300,7 @@ function file_list($message = '')
     if ($rs && numRows($rs)) {
         $show_authors = !has_single_author('txp_file');
 
-        echo n.tag(
-                toggle_box('files_detail'), 'div', array('class' => 'txp-list-options')).
+        echo n.tag(toggle_box('files_detail'), 'div', array('class' => 'txp-list-options')).
             n.tag_start('form', array(
                 'class'  => 'multi_edit_form',
                 'id'     => 'files_form',
@@ -310,45 +314,39 @@ function file_list($message = '')
             tr(
                 hCell(
                     fInput('checkbox', 'select_all', 0, '', '', '', '', '', 'select_all'),
-                        '', ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
+                    '', ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
                 ).
                 column_head(
                     'ID', 'id', 'file', true, $switch_dir, $crit, $search_method,
-                        (('id' == $sort) ? "$dir " : '').'txp-list-col-id'
+                    (('id' == $sort) ? "$dir " : '').'txp-list-col-id'
                 ).
                 column_head(
                     'file_name', 'filename', 'file', true, $switch_dir, $crit, $search_method,
-                        (('filename' == $sort) ? "$dir " : '').'txp-list-col-filename'
+                    (('filename' == $sort) ? "$dir " : '').'txp-list-col-filename'
                 ).
                 column_head(
                     'title', 'title', 'file', true, $switch_dir, $crit, $search_method,
-                        (('title' == $sort) ? "$dir " : '').'txp-list-col-title files_detail'
+                    (('title' == $sort) ? "$dir " : '').'txp-list-col-title files_detail'
                 ).
                 column_head(
                     'date', 'date', 'image', true, $switch_dir, $crit, $search_method,
-                        (('date' == $sort) ? "$dir " : '').'txp-list-col-created date files_detail'
+                    (('date' == $sort) ? "$dir " : '').'txp-list-col-created date files_detail'
                 ).
                 column_head(
                     'file_category', 'category', 'file', true, $switch_dir, $crit, $search_method,
-                        (('category' == $sort) ? "$dir " : '').'txp-list-col-category category'
+                    (('category' == $sort) ? "$dir " : '').'txp-list-col-category category'
                 ).
-                hCell(gTxt(
-                    'tags'), '', ' class="txp-list-col-tag-build files_detail" scope="col"'
-                ).
-                hCell(gTxt(
-                    'status'), '', ' class="txp-list-col-status" scope="col"'
-                ).
-                hCell(gTxt(
-                    'condition'), '', ' class="txp-list-col-condition" scope="col"'
-                ).
+                hCell(gTxt('tags'), '', ' class="txp-list-col-tag-build files_detail" scope="col"').
+                hCell(gTxt('status'), '', ' class="txp-list-col-status" scope="col"').
+                hCell(gTxt('condition'), '', ' class="txp-list-col-condition" scope="col"').
                 column_head(
                     'downloads', 'downloads', 'file', true, $switch_dir, $crit, $search_method,
-                        (('downloads' == $sort) ? "$dir " : '').'txp-list-col-downloads'
+                    (('downloads' == $sort) ? "$dir " : '').'txp-list-col-downloads'
                 ).
                 (
                     $show_authors
                     ? column_head('author', 'author', 'file', true, $switch_dir, $crit, $search_method,
-                        (('author' == $sort) ? "$dir " : '').'txp-list-col-author name')
+                      (('author' == $sort) ? "$dir " : '').'txp-list-col-author name')
                     : ''
                 )
             ).
@@ -430,43 +428,27 @@ function file_list($message = '')
             }
 
             echo tr(
-                td(
-                    $multi_edit, '', 'txp-list-col-multi-edit'
-                ).
-                hCell(
-                    $id_column, '', array(
+                td($multi_edit, '', 'txp-list-col-multi-edit').
+                hCell($id_column, '', array(
                         'class' => 'txp-list-col-id',
                         'scope' => 'row',
-                    )
-                ).
-                td(
-                    $name, '', 'txp-list-col-filename'
-                ).
-                td(
-                    txpspecialchars($title), '', 'txp-list-col-title files_detail'
-                ).
-                td(
-                    gTime($uDate), '', 'txp-list-col-created date files_detail'
-                ).
-                td(
-                    $category, '', 'txp-list-col-category category'.$vc
-                ).
+                )).
+                td($name, '', 'txp-list-col-filename').
+                td(txpspecialchars($title), '', 'txp-list-col-title files_detail').
+                td(gTime($uDate), '', 'txp-list-col-created date files_detail').
+                td($category, '', 'txp-list-col-category category'.$vc).
                 td(
                     href('Textile', $tag_url + array('type' => 'textile'), ' target="_blank" onclick="popWin(this.href); return false;"').
                     sp.span('&#124;', array('role' => 'separator')).
                     sp.href('Textpattern', $tag_url + array('type' => 'textpattern'), ' target="_blank" onclick="popWin(this.href); return false;"').
                     sp.span('&#124;', array('role' => 'separator')).
-                    sp.href('HTML', $tag_url + array('type' => 'html'), ' target="_blank" onclick="popWin(this.href); return false;"'), '', 'txp-list-col-tag-build files_detail').
-
-                td(
-                    $status, '', 'txp-list-col-status'
+                    sp.href('HTML', $tag_url + array('type' => 'html'), ' target="_blank" onclick="popWin(this.href); return false;"'),
+                    '',
+                    'txp-list-col-tag-build files_detail'
                 ).
-                td(
-                    $condition, '', 'txp-list-col-condition'
-                ).
-                td(
-                    $downloads, '', 'txp-list-col-downloads'
-                ).
+                td($status, '', 'txp-list-col-status').
+                td($condition, '', 'txp-list-col-condition').
+                td($downloads, '', 'txp-list-col-downloads').
                 (
                     $show_authors
                     ? td(span(txpspecialchars($realname), array('title' => $author)), '', 'txp-list-col-author name')
@@ -569,7 +551,7 @@ function file_multi_edit()
             $key = 'downloads';
             $val = 0;
             break;
-        case 'changestatus' :
+        case 'changestatus':
             $key = 'status';
             $val = ps('status');
 
@@ -699,94 +681,97 @@ function file_edit($message = '', $id = '')
             n.tag(
                 checkbox('publish_now', '1', $publish_now, '', 'publish_now').
                 n.tag(gTxt('set_to_now'), 'label', array('for' => 'publish_now')),
-                'div', array('class' => 'posted-now')
+                'div',
+                array('class' => 'posted-now')
             );
 
         echo n.tag_start('div', array('class' => 'txp-edit')).
-            hed(gTxt('edit_file'), 2).
-            $replace.
-            inputLabel(
-                'condition',
-                $condition,
-                '', '', array('class' => 'txp-form-field edit-file-condition')
-            ).
-            inputLabel(
-                'id',
-                $id,
-                'id', '', array('class' => 'txp-form-field edit-file-id')
-            ).
-            inputLabel(
-                'name',
-                $downloadlink,
-                '', '', array('class' => 'txp-form-field edit-file-name')
-            ).
-            inputLabel(
-                'download_count',
-                $downloads,
-                '', '', array('class' => 'txp-form-field edit-file-download-count')
-            ).
-            form(
-                (($file_exists)
-                ? inputLabel(
-                        'file_status',
-                        selectInput('status', $file_statuses, $status, false, '', 'file_status'),
-                        'file_status', '', array('class' => 'txp-form-field edit-file-status')
-                    ).
-                    $created.
-                    inputLabel(
-                        'file_title',
-                        fInput('text', 'title', $title, '', '', '', INPUT_REGULAR, '', 'file_title'),
-                        'title', '', array('class' => 'txp-form-field edit-file-title')
-                    ).
-                    inputLabel(
-                        'file_category',
-                        event_category_popup('file', $category, 'file_category').
-                        n.eLink('category', 'list', '', '', gTxt('edit'), '', '', '', 'txp-option-link'),
-                        'file_category', '', array('class' => 'txp-form-field edit-file-category')
-                    ).
-//                    inputLabel(
-//                        'perms',
-//                        selectInput('perms', $levels, $permissions),
-//                        'permissions'
-//                    ).
-                    inputLabel(
-                        'file_description',
-                        '<textarea id="file_description" name="description" cols="'.INPUT_LARGE.'" rows="'.TEXTAREA_HEIGHT_SMALL.'">'.$description.'</textarea>',
-                        'description', '', array('class' => 'txp-form-field txp-form-field-textarea edit-file-description')
-                    ).
-                    pluggable_ui('file_ui', 'extend_detail_form', '', $rs).
-                    graf(
-                        sLink('file', '', gTxt('cancel'), 'txp-button').
-                        fInput('submit', '', gTxt('save'), 'publish'),
-                        array('class' => 'txp-edit-actions')
-                    ).
-                    hInput('filename', $filename)
-                : (empty($existing_files)
-                        ? ''
-                        : gTxt('existing_file').selectInput('filename', $existing_files, '', 1)
-                    ).
-                    pluggable_ui('file_ui', 'extend_detail_form', '', $rs).
-                    graf(
-                        sLink('file', '', gTxt('cancel'), 'txp-button').
-                        fInput('submit', '', gTxt('save'), 'publish'),
-                        array('class' => 'txp-edit-actions')
-                    ).
-                    hInput('category', $category).
-                    hInput('perms', ($permissions == '-1') ? '' : $permissions).
-                    hInput('title', $title).
-                    hInput('description', $description).
-                    hInput('status', $status)
+        hed(gTxt('edit_file'), 2).
+        $replace.
+        inputLabel(
+            'condition', $condition, '', '',
+            array('class' => 'txp-form-field edit-file-condition')
+        ).
+        inputLabel(
+            'id', $id, 'id', '',
+            array('class' => 'txp-form-field edit-file-id')
+        ).
+        inputLabel(
+            'name', $downloadlink, '', '',
+            array('class' => 'txp-form-field edit-file-name')
+        ).
+        inputLabel(
+            'download_count', $downloads, '', '',
+            array('class' => 'txp-form-field edit-file-download-count')
+        ).
+        form(
+            (($file_exists)
+            ? inputLabel(
+                    'file_status',
+                    selectInput('status', $file_statuses, $status, false, '', 'file_status'),
+                    'file_status', '', array('class' => 'txp-form-field edit-file-status')
                 ).
-                eInput('file').
-                sInput('file_save').
-                hInput('id', $id).
-                hInput('sort', $sort).
-                hInput('dir', $dir).
-                hInput('page', $page).
-                hInput('crit', $crit).
-                hInput('search_method', $search_method),
-            '', '', 'post', 'file-detail '.(($file_exists) ? '' : 'not-').'exists', '', (($file_exists) ? 'file_details' : 'assign_file')).
-            n.tag_end('div');
+                $created.
+                inputLabel(
+                    'file_title',
+                    fInput('text', 'title', $title, '', '', '', INPUT_REGULAR, '', 'file_title'),
+                    'title', '', array('class' => 'txp-form-field edit-file-title')
+                ).
+                inputLabel(
+                    'file_category',
+                    event_category_popup('file', $category, 'file_category').
+                    n.eLink('category', 'list', '', '', gTxt('edit'), '', '', '', 'txp-option-link'),
+                    'file_category',
+                    '',
+                    array('class' => 'txp-form-field edit-file-category')
+                ).
+//              inputLabel(
+//                  'perms',
+//                  selectInput('perms', $levels, $permissions),
+//                  'permissions'
+//              ).
+                inputLabel(
+                    'file_description',
+                    '<textarea id="file_description" name="description" cols="'.INPUT_LARGE.'" rows="'.TEXTAREA_HEIGHT_SMALL.'">'.$description.'</textarea>',
+                    'description', '', array('class' => 'txp-form-field txp-form-field-textarea edit-file-description')
+                ).
+                pluggable_ui('file_ui', 'extend_detail_form', '', $rs).
+                graf(
+                    sLink('file', '', gTxt('cancel'), 'txp-button').
+                    fInput('submit', '', gTxt('save'), 'publish'),
+                    array('class' => 'txp-edit-actions')
+                ).
+                hInput('filename', $filename)
+            : (empty($existing_files)
+                    ? ''
+                    : gTxt('existing_file').selectInput('filename', $existing_files, '', 1)
+                ).
+                pluggable_ui('file_ui', 'extend_detail_form', '', $rs).
+                graf(
+                    sLink('file', '', gTxt('cancel'), 'txp-button').
+                    fInput('submit', '', gTxt('save'), 'publish'),
+                    array('class' => 'txp-edit-actions')
+                ).
+                hInput('category', $category).
+                hInput('perms', ($permissions == '-1') ? '' : $permissions).
+                hInput('title', $title).
+                hInput('description', $description).
+                hInput('status', $status)
+            ).
+            eInput('file').
+            sInput('file_save').
+            hInput('id', $id).
+            hInput('sort', $sort).
+            hInput('dir', $dir).
+            hInput('page', $page).
+            hInput('crit', $crit).
+            hInput('search_method', $search_method),
+            '',
+            '',
+            'post',
+            'file-detail '.(($file_exists) ? '' : 'not-').'exists', '', (($file_exists) ? 'file_details' : 'assign_file')
+        ).
+        n.tag_end('div');
     }
 }
 
@@ -800,7 +785,8 @@ function file_db_add($filename, $category, $permissions, $description, $size, $t
         return false;
     }
 
-    $rs = safe_insert('txp_file',
+    $rs = safe_insert(
+        'txp_file',
         "filename = '$filename',
          title = '$title',
          category = '$category',
@@ -810,7 +796,8 @@ function file_db_add($filename, $category, $permissions, $description, $size, $t
          created = NOW(),
          modified = NOW(),
          author = '".doSlash($txp_user)."'
-    ");
+        "
+    );
 
     if ($rs) {
         $GLOBALS['ID'] = $rs;

--- a/textpattern/include/txp_form.php
+++ b/textpattern/include/txp_form.php
@@ -144,7 +144,9 @@ function form_list($curname)
 
             if (!in_array($name, $essential_forms)) {
                 $modbox = span(
-                    checkbox('selected_forms[]', txpspecialchars($name), false), array('class' => 'switcher-action'));
+                    checkbox('selected_forms[]', txpspecialchars($name), false),
+                    array('class' => 'switcher-action')
+                );
             } else {
                 $modbox = '';
             }
@@ -279,7 +281,6 @@ function form_edit($message = '')
             array('', 'instructions_form_type'),
             array('class' => 'txp-form-field')
         );
-
     } else {
         $name_widgets = inputLabel(
             'new_form',
@@ -316,13 +317,17 @@ function form_edit($message = '')
     }
 
     $buttons = graf(
-        tag_void('input', array(
-            'class'  => 'publish',
-            'type'   => 'submit',
-            'method' => 'post',
-            'value'  =>  gTxt('save'),
-            'form'   => 'form_form',
-        )), ' class="txp-save"'
+        tag_void(
+            'input',
+            array(
+                'class'  => 'publish',
+                'type'   => 'submit',
+                'method' => 'post',
+                'value'  =>  gTxt('save'),
+                'form'   => 'form_form',
+            )
+        ),
+        ' class="txp-save"'
     ).
     graf(
         sLink('form', 'form_create', '<span class="ui-icon ui-extra-icon-new-document"></span> '.gTxt('create_new_form'), 'txp-new').
@@ -390,9 +395,16 @@ function form_edit($message = '')
                 'form_code',
                 array('', 'instructions_form_code'),
                 array('class' => 'txp-form-field')
-            )
-            , '', '', 'post', '', '', 'form_form'),
-        'div', array(
+            ),
+            '',
+            '',
+            'post',
+            '',
+            '',
+            'form_form'
+        ),
+        'div',
+        array(
             'class' => 'txp-layout-4col-cell-1-2-3',
             'id'    => 'main_content',
             'role'  => 'region',
@@ -404,7 +416,8 @@ function form_edit($message = '')
     echo n.tag(
         $buttons.
         form_list($name).n,
-        'div', array(
+        'div',
+        array(
             'class' => 'txp-layout-4col-cell-4alt',
             'id'    => 'content_switcher',
             'role'  => 'region',
@@ -474,10 +487,10 @@ function form_save()
                 if ($savenew or $copy) {
                     if ($newname) {
                         if (safe_insert(
-                                'txp_form',
-                                "Form = '$Form',
-                                type = '$type',
-                                name = '".doSlash($newname)."'"
+                            'txp_form',
+                            "Form = '$Form',
+                            type = '$type',
+                            name = '".doSlash($newname)."'"
                         )) {
                             update_lastmod('form_created', compact('newname', 'name', 'type', 'Form'));
                             $message = gTxt('form_created', array('{name}' => $newname));
@@ -491,11 +504,11 @@ function form_save()
                     }
                 } else {
                     if (safe_update(
-                            'txp_form',
-                            "Form = '$Form',
-                            type = '$type',
-                            name = '".doSlash($newname)."'",
-                            "name = '".doSlash($name)."'"
+                        'txp_form',
+                        "Form = '$Form',
+                        type = '$type',
+                        name = '".doSlash($newname)."'",
+                        "name = '".doSlash($name)."'"
                     )) {
                         update_lastmod('form_saved', compact('newname', 'name', 'type', 'Form'));
                         $message = gTxt('form_updated', array('{name}' => $name));

--- a/textpattern/include/txp_image.php
+++ b/textpattern/include/txp_image.php
@@ -130,7 +130,8 @@ function image_list($message = '')
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
-    $search = new Filter($event,
+    $search = new Filter(
+        $event,
         array(
             'id' => array(
                 'column' => 'txp_image.id',
@@ -194,12 +195,15 @@ function image_list($message = '')
 
     echo n.tag(
         hed(gTxt('tab_image'), 1, array('class' => 'txp-heading')),
-        'div', array('class' => 'txp-layout-2col-cell-1'));
+        'div',
+        array('class' => 'txp-layout-2col-cell-1')
+    );
 
     $searchBlock =
         n.tag(
             $search->renderForm('image_list', $search_render_options),
-            'div', array(
+            'div',
+            array(
                 'class' => 'txp-layout-2col-cell-2',
                 'id'    => $event.'_control',
             )
@@ -218,7 +222,8 @@ function image_list($message = '')
         $createBlock[] =
             n.tag(
                 n.upload_form('upload_image', 'upload_image', 'image_insert', 'image', '', $file_max_upload_size, '', '', ''),
-                'div', array('class' => 'txp-control-panel')
+                'div',
+                array('class' => 'txp-control-panel')
             );
     }
 
@@ -285,8 +290,12 @@ function image_list($message = '')
     if ($rs && numRows($rs)) {
         $show_authors = !has_single_author('txp_image');
 
-        echo n.tag(
-                toggle_box('images_detail'), 'div', array('class' => 'txp-list-options')).
+        echo
+            n.tag(
+                toggle_box('images_detail'),
+                'div',
+                array('class' => 'txp-list-options')
+            ).
             n.tag_start('form', array(
                 'class'  => 'multi_edit_form',
                 'id'     => 'images_form',
@@ -300,35 +309,36 @@ function image_list($message = '')
             tr(
                 hCell(
                     fInput('checkbox', 'select_all', 0, '', '', '', '', '', 'select_all'),
-                        '', ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
+                    '',
+                    ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
                 ).
                 column_head(
                     'ID', 'id', 'image', true, $switch_dir, $crit, $search_method,
-                        (('id' == $sort) ? "$dir " : '').'txp-list-col-id'
+                    (('id' == $sort) ? "$dir " : '').'txp-list-col-id'
                 ).
                 column_head(
                     'name', 'name', 'image', true, $switch_dir, $crit, $search_method,
-                        (('name' == $sort) ? "$dir " : '').'txp-list-col-name'
+                    (('name' == $sort) ? "$dir " : '').'txp-list-col-name'
                 ).
                 column_head(
                     'date', 'date', 'image', true, $switch_dir, $crit, $search_method,
-                        (('date' == $sort) ? "$dir " : '').'txp-list-col-created date images_detail'
+                    (('date' == $sort) ? "$dir " : '').'txp-list-col-created date images_detail'
                 ).
                 column_head(
                     'thumbnail', 'thumbnail', 'image', true, $switch_dir, $crit, $search_method,
-                        (('thumbnail' == $sort) ? "$dir " : '').'txp-list-col-thumbnail'
+                    (('thumbnail' == $sort) ? "$dir " : '').'txp-list-col-thumbnail'
                 ).
                 hCell(
                     gTxt('tags'), '', ' class="txp-list-col-tag-build images_detail" scope="col"'
                 ).
                 column_head(
                     'image_category', 'category', 'image', true, $switch_dir, $crit, $search_method,
-                        (('category' == $sort) ? "$dir " : '').'txp-list-col-category category'
+                    (('category' == $sort) ? "$dir " : '').'txp-list-col-category category'
                 ).
                 (
                     $show_authors
                     ? column_head('author', 'author', 'image', true, $switch_dir, $crit, $search_method,
-                        (('author' == $sort) ? "$dir " : '').'txp-list-col-author name')
+                      (('author' == $sort) ? "$dir " : '').'txp-list-col-author name')
                     : ''
                 )
             ).
@@ -389,35 +399,29 @@ function image_list($message = '')
             $can_edit = has_privs('image.edit') || ($author === $txp_user && has_privs('image.edit.own'));
 
             echo tr(
-                td(
-                    $can_edit ? fInput('checkbox', 'selected[]', $id) : '&#160;', '', 'txp-list-col-multi-edit'
-                ).
+                td($can_edit ? fInput('checkbox', 'selected[]', $id) : '&#160;', '', 'txp-list-col-multi-edit').
                 hCell(
                     ($can_edit ? href($id, $edit_url, array('title' => gTxt('edit'))) : $id).
                     span(
                         sp.span('&#124;', array('role' => 'separator')).
                         sp.href(gTxt('view'), imagesrcurl($id, $ext)),
                         array('class' => 'txp-option-link images_detail')
-                    ), '', array(
+                    ),
+                    '',
+                    array(
                         'class' => 'txp-list-col-id',
                         'scope' => 'row',
                     )
                 ).
+                td(($can_edit ? href($name, $edit_url, ' title="'.gTxt('edit').'"') : $name), '', 'txp-list-col-name').
+                td(gTime($uDate), '', 'txp-list-col-created date images_detail').
                 td(
-                    ($can_edit ? href($name, $edit_url, ' title="'.gTxt('edit').'"') : $name), '', 'txp-list-col-name'
+                    pluggable_ui('image_ui', 'thumbnail', ($can_edit ? href($thumbnail, $edit_url) : $thumbnail), $a),
+                    '',
+                    'txp-list-col-thumbnail'.($thumbexists ? ' has-thumbnail' : '')
                 ).
-                td(
-                    gTime($uDate), '', 'txp-list-col-created date images_detail'
-                ).
-                td(
-                    pluggable_ui('image_ui', 'thumbnail', ($can_edit ? href($thumbnail, $edit_url) : $thumbnail), $a), '', 'txp-list-col-thumbnail'.($thumbexists ? ' has-thumbnail' : '')
-                ).
-                td(
-                    $tagbuilder, '', 'txp-list-col-tag-build images_detail'
-                ).
-                td(
-                    $category, '', 'txp-list-col-category category'.$vc
-                ).
+                td($tagbuilder, '', 'txp-list-col-tag-build images_detail').
+                td($category, '', 'txp-list-col-category category'.$vc).
                 (
                     $show_authors
                     ? td(span(txpspecialchars($realname), array('title' => $author)), '', 'txp-list-col-author name')
@@ -608,18 +612,18 @@ function image_edit($message = '', $id = '')
         $thumbBlock = array();
 
         $imageBlock[] = pluggable_ui(
-                'image_ui',
-                'image_edit',
-                upload_form('replace_image', 'replace_image_form', 'image_replace', 'image', $id, $file_max_upload_size, 'image-upload', ' image-replace'),
-                $rs
-            );
+            'image_ui',
+            'image_edit',
+            upload_form('replace_image', 'replace_image_form', 'image_replace', 'image', $id, $file_max_upload_size, 'image-upload', ' image-replace'),
+            $rs
+        );
 
         $imageBlock[] = pluggable_ui(
-                'image_ui',
-                'fullsize_image',
-                $img,
-                $rs
-            );
+            'image_ui',
+            'fullsize_image',
+            $img,
+            $rs
+        );
 
         $thumbBlock[] = hed(gTxt('create_thumbnail').popHelp('create_thumbnail'), 3);
 
@@ -636,14 +640,15 @@ function image_edit($message = '', $id = '')
                 'thumbnail_create',
                 form(
                     graf(
-                            n.'<label for="width">'.gTxt('thumb_width').'</label>'.
-                            fInput('text', 'width', @$thumb_w, 'input-xsmall', '', '', INPUT_XSMALL, '', 'width').
-                            n.'<label for="height">'.gTxt('thumb_height').'</label>'.
-                            fInput('text', 'height', @$thumb_h, 'input-xsmall', '', '', INPUT_XSMALL, '', 'height').
-                            n.'<label for="crop">'.gTxt('keep_square_pixels').'</label>'.
-                            checkbox('crop', 1, @$prefs['thumb_crop'], '', 'crop').
-                            fInput('submit', '', gTxt('create'))
-                        , ' class="edit-alter-thumbnail"').
+                        n.'<label for="width">'.gTxt('thumb_width').'</label>'.
+                        fInput('text', 'width', @$thumb_w, 'input-xsmall', '', '', INPUT_XSMALL, '', 'width').
+                        n.'<label for="height">'.gTxt('thumb_height').'</label>'.
+                        fInput('text', 'height', @$thumb_h, 'input-xsmall', '', '', INPUT_XSMALL, '', 'height').
+                        n.'<label for="crop">'.gTxt('keep_square_pixels').'</label>'.
+                        checkbox('crop', 1, @$prefs['thumb_crop'], '', 'crop').
+                        fInput('submit', '', gTxt('create')),
+                        ' class="edit-alter-thumbnail"'
+                    ).
                     hInput('id', $id).
                     eInput('image').
                     sInput('thumbnail_create').
@@ -651,8 +656,14 @@ function image_edit($message = '', $id = '')
                     hInput('dir', $dir).
                     hInput('page', $page).
                     hInput('search_method', $search_method).
-                    hInput('crit', $crit)
-                    , '', '', 'post', '', '', 'thumbnail_alter_form'),
+                    hInput('crit', $crit),
+                    '',
+                    '',
+                    'post',
+                    '',
+                    '',
+                    'thumbnail_alter_form'
+                ),
                 $rs
             )
             : '';
@@ -669,56 +680,67 @@ function image_edit($message = '', $id = '')
         );
 
         echo n.tag(
-                    hed(gTxt('edit_image'), 1, array('class' => 'txp-heading')).
-                    n.implode(n, $imageBlock).
-                    '<hr />'.
-                    tag(implode(n, $thumbBlock), 'section', array('class' => 'thumbnail-alter')),
-                'div',
-                array('class' => 'txp-layout-4col-cell-1-2-3')
-            ).
-            '<div class="txp-layout-4col-cell-4alt">',
-                form(
-                    graf(fInput('submit', '', gTxt('save'), 'publish'), array('class' => 'txp-save')).
-                    wrapGroup(
-                        'image-details',
-                        inputLabel(
-                            'id',
-                            $id,
-                            'id', '', array('class' => 'txp-form-field edit-image-id')
-                        ).
-                        inputLabel(
-                            'image_name',
-                            fInput('text', 'name', $name, '', '', '', INPUT_REGULAR, '', 'image_name'),
-                            'image_name', '', array('class' => 'txp-form-field edit-image-name')
-                        ).
-                        inputLabel(
-                            'image_category',
-                            event_category_popup('image', $category, 'image_category').
-                            n.eLink('category', 'list', '', '', gTxt('edit'), '', '', '', 'txp-option-link'),
-                            'image_category', '', array('class' => 'txp-form-field edit-image-category')
-                        ).
-                        inputLabel(
-                            'image_alt_text',
-                            fInput('text', 'alt', $alt, '', '', '', INPUT_REGULAR, '', 'image_alt_text'),
-                            'alt_text', '', array('class' => 'txp-form-field edit-image-alt-text')
-                        ).
-                        inputLabel(
-                            'image_caption',
-                            '<textarea id="image_caption" name="caption" cols="'.INPUT_LARGE.'" rows="'.TEXTAREA_HEIGHT_SMALL.'">'.$caption.'</textarea>',
-                            'caption', '', array('class' => 'txp-form-field txp-form-field-textarea edit-image-caption')
-                        ).
-                        pluggable_ui('image_ui', 'extend_detail_form', '', $rs).
-                        hInput('id', $id).
-                        eInput('image').
-                        sInput('image_save').
-                        hInput('sort', $sort).
-                        hInput('dir', $dir).
-                        hInput('page', $page).
-                        hInput('search_method', $search_method).
-                        hInput('crit', $crit),
-                        'image_details'),
-                    '', '', 'post', '', '', 'image_details_form'),
-            '</div>';
+            hed(gTxt('edit_image'), 1, array('class' => 'txp-heading')).
+            n.implode(n, $imageBlock).
+            '<hr />'.
+            tag(implode(n, $thumbBlock), 'section', array('class' => 'thumbnail-alter')),
+            'div',
+            array('class' => 'txp-layout-4col-cell-1-2-3')
+        ).
+        '<div class="txp-layout-4col-cell-4alt">',
+            form(
+                graf(fInput('submit', '', gTxt('save'), 'publish'), array('class' => 'txp-save')).
+                wrapGroup(
+                    'image-details',
+                    inputLabel('id', $id, 'id', '', array('class' => 'txp-form-field edit-image-id')).
+                    inputLabel(
+                        'image_name',
+                        fInput('text', 'name', $name, '', '', '', INPUT_REGULAR, '', 'image_name'),
+                        'image_name',
+                        '',
+                        array('class' => 'txp-form-field edit-image-name')
+                    ).
+                    inputLabel(
+                        'image_category',
+                        event_category_popup('image', $category, 'image_category').
+                        n.eLink('category', 'list', '', '', gTxt('edit'), '', '', '', 'txp-option-link'),
+                        'image_category',
+                        '',
+                        array('class' => 'txp-form-field edit-image-category')
+                    ).
+                    inputLabel(
+                        'image_alt_text',
+                        fInput('text', 'alt', $alt, '', '', '', INPUT_REGULAR, '', 'image_alt_text'),
+                        'alt_text',
+                        '',
+                        array('class' => 'txp-form-field edit-image-alt-text')
+                    ).
+                    inputLabel(
+                        'image_caption',
+                        '<textarea id="image_caption" name="caption" cols="'.INPUT_LARGE.'" rows="'.TEXTAREA_HEIGHT_SMALL.'">'.$caption.'</textarea>',
+                        'caption',
+                        '',
+                        array('class' => 'txp-form-field txp-form-field-textarea edit-image-caption')
+                    ).
+                    pluggable_ui('image_ui', 'extend_detail_form', '', $rs).
+                    hInput('id', $id).
+                    eInput('image').
+                    sInput('image_save').
+                    hInput('sort', $sort).
+                    hInput('dir', $dir).
+                    hInput('page', $page).
+                    hInput('search_method', $search_method).
+                    hInput('crit', $crit),
+                    'image_details'
+                ),
+                '',
+                '',
+                'post',
+                '',
+                '',
+                'image_details_form'
+            ),
+        '</div>';
     }
 }
 

--- a/textpattern/include/txp_lang.php
+++ b/textpattern/include/txp_lang.php
@@ -101,9 +101,9 @@ function list_languages($message = '')
             languages('language', $active_lang).
             eInput('lang').
             sInput('save_language')
-        ), 'div', array(
-            'class' => 'txp-control-panel',
-        )
+        ),
+        'div',
+        array('class' => 'txp-control-panel')
     );
 
     $client = new IXR_Client(RPC_SERVER);
@@ -195,7 +195,8 @@ function list_languages($message = '')
                     ? n.span(safe_strftime('%d %b %Y %X', $langdat['db_lastmod']), array('class' => 'date modified'))
                     : ''
                 )
-            ), (isset($langdat['db_lastmod']) && $rpc_updated)
+            ),
+            (isset($langdat['db_lastmod']) && $rpc_updated)
                 ? ' class="highlight lang-value"'
                 : ' class="lang-value"'
         );
@@ -221,16 +222,19 @@ function list_languages($message = '')
             n.span(safe_strftime(get_pref('archive_dateformat'), $langdat['file_lastmod']), array(
                 'class' => 'date '.($file_updated ? 'created' : 'modified'),
             ))
-            : '-', ' class="lang-value languages_detail'.((isset($langdat['db_lastmod']) && $rpc_updated) ? ' highlight' : '').'"'
+            : '-',
+              ' class="lang-value languages_detail'.((isset($langdat['db_lastmod']) && $rpc_updated) ? ' highlight' : '').'"'
         );
 
         $list .= tr(
-        // Lang-Name and Date.
+            // Lang-Name and Date.
             hCell(
-                gTxt($langname), '', (isset($langdat['db_lastmod']) && $rpc_updated)
-                        ? ' class="highlight lang-label" scope="row"'
-                        : ' class="lang-label" scope="row"'
-                ).
+                gTxt($langname),
+                '',
+                (isset($langdat['db_lastmod']) && $rpc_updated)
+                ? ' class="highlight lang-label" scope="row"'
+                : ' class="lang-label" scope="row"'
+            ).
             n.$rpc_install.
             n.$lang_file.
             tda((in_array($langname, $installed_lang) ? dLink('lang', 'remove_language', 'lang_code', $langname, 1) : '-'), ' class="languages_detail'.((isset($langdat['db_lastmod']) && $rpc_updated) ? ' highlight' : '').'"')
@@ -240,9 +244,12 @@ function list_languages($message = '')
     // Output table and content.
     pagetop(gTxt('tab_languages'), $message);
 
-    echo n.tag(
-        hed(gTxt('tab_languages'), 1, array('class' => 'txp-heading')),
-        'div', array('class' => 'txp-layout-2col-cell-1')).
+    echo
+        n.tag(
+            hed(gTxt('tab_languages'), 1, array('class' => 'txp-heading')),
+            'div',
+            array('class' => 'txp-layout-2col-cell-1')
+        ).
         n.tag_start('div', array(
             'class' => 'txp-layout-1col',
             'id'    => 'language_container',
@@ -253,24 +260,15 @@ function list_languages($message = '')
     }
 
     echo $lang_form,
-        n.tag(
-            toggle_box('languages_detail'), 'div', array('class' => 'txp-list-options')).
+        n.tag(toggle_box('languages_detail'), 'div', array('class' => 'txp-list-options')).
         n.tag_start('div', array('class' => 'txp-listtables')).
         n.tag_start('table', array('class' => 'txp-list')).
         n.tag_start('thead').
         tr(
-            hCell(
-                gTxt('language'), '', ' scope="col"'
-            ).
-            hCell(
-                gTxt('from_server').popHelp('install_lang_from_server'), '', ' scope="col"'
-            ).
-            hCell(
-                gTxt('from_file').popHelp('install_lang_from_file'), '', ' class="languages_detail" scope="col"'
-            ).
-            hCell(
-                gTxt('remove_lang').popHelp('remove_lang'), '', ' class="languages_detail" scope="col"'
-            )
+            hCell(gTxt('language'), '', ' scope="col"').
+            hCell(gTxt('from_server').popHelp('install_lang_from_server'), '', ' scope="col"').
+            hCell(gTxt('from_file').popHelp('install_lang_from_file'), '', ' class="languages_detail" scope="col"').
+            hCell(gTxt('remove_lang').popHelp('remove_lang'), '', ' class="languages_detail" scope="col"')
         ).
         n.tag_end('thead').
         n.tag_start('tbody').
@@ -286,9 +284,17 @@ function list_languages($message = '')
                 n.'<textarea class="code" id="textpack-install" name="textpack" cols="'.INPUT_LARGE.'" rows="'.TEXTAREA_HEIGHT_SMALL.'" dir="ltr"></textarea>'.
                 fInput('submit', 'install_new', gTxt('upload')).
                 eInput('lang').
-                sInput('get_textpack')
-                , '', '', 'post', '', '', 'text_uploader'
-            ), 'div', array('class' => 'txp-control-panel')).
+                sInput('get_textpack'),
+                '',
+                '',
+                'post',
+                '',
+                '',
+                'text_uploader'
+            ),
+            'div',
+            array('class' => 'txp-control-panel')
+        ).
 
         n.tag_end('div');
 }

--- a/textpattern/include/txp_link.php
+++ b/textpattern/include/txp_link.php
@@ -125,7 +125,8 @@ function link_list($message = '')
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
-    $search = new Filter($event,
+    $search = new Filter(
+        $event,
         array(
             'id' => array(
                 'column' => 'txp_link.id',
@@ -180,31 +181,36 @@ function link_list($message = '')
 
     echo n.tag(
         hed(gTxt('tab_link'), 1, array('class' => 'txp-heading')),
-        'div', array('class' => 'txp-layout-2col-cell-1'));
+        'div',
+        array('class' => 'txp-layout-2col-cell-1')
+    );
 
-    $searchBlock =
-        n.tag(
-            $search->renderForm('link_list', $search_render_options),
-            'div', array(
-                'class' => 'txp-layout-2col-cell-2',
-                'id'    => $event.'_control',
-            )
-        );
+    $searchBlock = n.tag(
+        $search->renderForm('link_list', $search_render_options),
+        'div',
+        array(
+            'class' => 'txp-layout-2col-cell-2',
+            'id'    => $event.'_control',
+        )
+    );
 
     $createBlock = array();
 
     if (has_privs('link.edit')) {
-        $createBlock[] =
-            n.tag(
-                sLink('link', 'link_edit', gTxt('add_new_link'), 'txp-button'),
-                'div', array('class' => 'txp-control-panel')
-            );
+        $createBlock[] = n.tag(
+            sLink('link', 'link_edit', gTxt('add_new_link'), 'txp-button'),
+            'div',
+            array('class' => 'txp-control-panel')
+        );
     }
 
-    $contentBlockStart = n.tag_start('div', array(
+    $contentBlockStart = n.tag_start(
+        'div',
+        array(
             'class' => 'txp-layout-1col',
             'id'    => $event.'_container',
-        ));
+        )
+    );
 
     $createBlock = implode(n, $createBlock);
 
@@ -256,8 +262,8 @@ function link_list($message = '')
     if ($rs && numRows($rs)) {
         $show_authors = !has_single_author('txp_link');
 
-        echo n.tag(
-                toggle_box('links_detail'), 'div', array('class' => 'txp-list-options')).
+        echo
+            n.tag(toggle_box('links_detail'), 'div', array('class' => 'txp-list-options')).
             n.tag_start('form', array(
                 'class'  => 'multi_edit_form',
                 'id'     => 'links_form',
@@ -271,36 +277,37 @@ function link_list($message = '')
             tr(
                 hCell(
                     fInput('checkbox', 'select_all', 0, '', '', '', '', '', 'select_all'),
-                        '', ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
+                    '',
+                    ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
                 ).
                 column_head(
                     'ID', 'id', 'link', true, $switch_dir, $crit, $search_method,
-                        (('id' == $sort) ? "$dir " : '').'txp-list-col-id'
+                    (('id' == $sort) ? "$dir " : '').'txp-list-col-id'
                 ).
                 column_head(
                     'link_name', 'name', 'link', true, $switch_dir, $crit, $search_method,
-                        (('name' == $sort) ? "$dir " : '').'txp-list-col-name'
+                    (('name' == $sort) ? "$dir " : '').'txp-list-col-name'
                 ).
                 column_head(
                     'description', 'description', 'link', true, $switch_dir, $crit, $search_method,
-                        (('description' == $sort) ? "$dir " : '').'txp-list-col-description links_detail'
+                    (('description' == $sort) ? "$dir " : '').'txp-list-col-description links_detail'
                 ).
                 column_head(
                     'link_category', 'category', 'link', true, $switch_dir, $crit, $search_method,
-                        (('category' == $sort) ? "$dir " : '').'txp-list-col-category category'
+                    (('category' == $sort) ? "$dir " : '').'txp-list-col-category category'
                 ).
                 column_head(
                     'url', 'url', 'link', true, $switch_dir, $crit, $search_method,
-                        (('url' == $sort) ? "$dir " : '').'txp-list-col-url'
+                    (('url' == $sort) ? "$dir " : '').'txp-list-col-url'
                 ).
                 column_head(
                     'date', 'date', 'link', true, $switch_dir, $crit, $search_method,
-                        (('date' == $sort) ? "$dir " : '').'txp-list-col-created date links_detail'
+                    (('date' == $sort) ? "$dir " : '').'txp-list-col-created date links_detail'
                 ).
                 (
                     $show_authors
                     ? column_head('author', 'author', 'link', true, $switch_dir, $crit, $search_method,
-                        (('author' == $sort) ? "$dir " : '').'txp-list-col-author name')
+                      (('author' == $sort) ? "$dir " : '').'txp-list-col-author name')
                     : ''
                 )
             ).
@@ -334,27 +341,25 @@ function link_list($message = '')
             $view_url = txpspecialchars($link_url);
 
             echo tr(
-                td(
-                    fInput('checkbox', 'selected[]', $link_id), '', 'txp-list-col-multi-edit'
-                ).
+                td(fInput('checkbox', 'selected[]', $link_id), '', 'txp-list-col-multi-edit').
                 hCell(
-                    ($can_edit ? href($link_id, $edit_url, ' title="'.gTxt('edit').'"') : $link_id), '', ' class="txp-list-col-id" scope="row"'
+                    ($can_edit ? href($link_id, $edit_url, ' title="'.gTxt('edit').'"') : $link_id),
+                    '',
+                    ' class="txp-list-col-id" scope="row"'
                 ).
                 td(
-                    ($can_edit ? href(txpspecialchars($link_linkname), $edit_url, ' title="'.gTxt('edit').'"') : txpspecialchars($link_linkname)), '', 'txp-list-col-name'
+                    (
+                        $can_edit
+                        ? href(txpspecialchars($link_linkname), $edit_url, ' title="'.gTxt('edit').'"')
+                        : txpspecialchars($link_linkname)
+                    ),
+                    '',
+                    'txp-list-col-name'
                 ).
-                td(
-                    txpspecialchars($link_description), '', 'txp-list-col-description links_detail'
-                ).
-                td(
-                    $link_category, '', 'txp-list-col-category category'.$vc
-                ).
-                td(
-                    href($view_url, $view_url, ' rel="external" target="_blank"'), '', 'txp-list-col-url'
-                ).
-                td(
-                    gTime($link_uDate), '', 'txp-list-col-created date links_detail'
-                ).
+                td(txpspecialchars($link_description), '', 'txp-list-col-description links_detail').
+                td($link_category, '', 'txp-list-col-category category'.$vc).
+                td(href($view_url, $view_url, ' rel="external" target="_blank"'), '', 'txp-list-col-url').
+                td(gTime($link_uDate), '', 'txp-list-col-created date links_detail').
                 (
                     $show_authors
                     ? td(span(txpspecialchars($link_realname), array('title' => $link_author)), '', 'txp-list-col-author name')
@@ -364,19 +369,19 @@ function link_list($message = '')
         }
 
         echo n.tag_end('tbody').
-            n.tag_end('table').
-            n.tag_end('div').
-            link_multiedit_form($page, $sort, $dir, $crit, $search_method).
-            tInput().
-            n.tag_end('form').
+             n.tag_end('table').
+             n.tag_end('div').
+             link_multiedit_form($page, $sort, $dir, $crit, $search_method).
+             tInput().
+             n.tag_end('form').
 
-            n.tag_start('div', array(
-                'class' => 'txp-navigation',
-                'id'    => $event.'_navigation',
-            )).
-            pageby_form('link', $link_list_pageby).
-            nav_form('link', $page, $numPages, $sort, $dir, $crit, $search_method, $total, $limit).
-            n.tag_end('div');
+             n.tag_start('div', array(
+                 'class' => 'txp-navigation',
+                 'id'    => $event.'_navigation',
+             )).
+             pageby_form('link', $link_list_pageby).
+             nav_form('link', $page, $numPages, $sort, $dir, $crit, $search_method, $total, $limit).
+             n.tag_end('div');
     }
 
     echo n.tag_end('div');
@@ -423,29 +428,39 @@ function link_edit($message = '')
             inputLabel(
                 'link_name',
                 fInput('text', 'linkname', $linkname, '', '', '', INPUT_REGULAR, '', 'link_name'),
-                'title', '', array('class' => 'txp-form-field edit-link-name')
+                'title',
+                '',
+                array('class' => 'txp-form-field edit-link-name')
             ).
             inputLabel(
                 'link_sort',
                 fInput('text', 'linksort', $linksort, 'input-medium', '', '', INPUT_MEDIUM, '', 'link_sort'),
-                'sort_value', 'link_sort', array('class' => 'txp-form-field edit-link-sort')
+                'sort_value',
+                'link_sort',
+                array('class' => 'txp-form-field edit-link-sort')
             ).
             // TODO: maybe use type="url" once browsers are less strict.
             inputLabel(
                 'link_url',
                 fInput('text', 'url', $url, '', '', '', INPUT_REGULAR, '', 'link_url'),
-                'url', 'link_url', array('class' => 'txp-form-field edit-link-url')
+                'url',
+                'link_url',
+                array('class' => 'txp-form-field edit-link-url')
             ).
             inputLabel(
                 'link_category',
                 event_category_popup('link', $category, 'link_category').
                 n.eLink('category', 'list', '', '', gTxt('edit'), '', '', '', 'txp-option-link'),
-                'link_category', 'link_category', array('class' => 'txp-form-field edit-link-category')
+                'link_category',
+                'link_category',
+                array('class' => 'txp-form-field edit-link-category')
             ).
             inputLabel(
                 'link_description',
                 '<textarea id="link_description" name="description" cols="'.INPUT_LARGE.'" rows="'.TEXTAREA_HEIGHT_SMALL.'">'.txpspecialchars($description).'</textarea>',
-                'description', 'link_description', array('class' => 'txp-form-field txp-form-field-textarea edit-link-description')
+                'description',
+                'link_description',
+                array('class' => 'txp-form-field txp-form-field-textarea edit-link-description')
             ).
             pluggable_ui('link_ui', 'extend_detail_form', '', $rs).
             graf(
@@ -458,7 +473,13 @@ function link_edit($message = '')
             hInput('id', $id).
             hInput('search_method', gps('search_method')).
             hInput('crit', gps('crit')),
-        '', '', 'post', 'txp-edit', '', 'link_details');
+            '',
+            '',
+            'post',
+            'txp-edit',
+            '',
+            'link_details'
+        );
     }
 }
 
@@ -514,24 +535,28 @@ function link_save()
 
     if ($validator->validate()) {
         if ($id) {
-            $ok = safe_update('txp_link',
-                "category   = '$category',
-                url         = '".trim($url)."',
-                linkname    = '$linkname',
-                linksort    = '$linksort',
-                description = '$description',
-                author      = '".doSlash($txp_user)."'",
+            $ok = safe_update(
+                'txp_link',
+                "category    = '$category',
+                 url         = '".trim($url)."',
+                 linkname    = '$linkname',
+                 linksort    = '$linksort',
+                 description = '$description',
+                 author      = '".doSlash($txp_user)."'
+                ",
                 "id = $id"
             );
         } else {
-            $ok = safe_insert('txp_link',
-                "category   = '$category',
-                date        = NOW(),
-                url         = '".trim($url)."',
-                linkname    = '$linkname',
-                linksort    = '$linksort',
-                description = '$description',
-                author      = '".doSlash($txp_user)."'"
+            $ok = safe_insert(
+                'txp_link',
+                "category    = '$category',
+                 date        = NOW(),
+                 url         = '".trim($url)."',
+                 linkname    = '$linkname',
+                 linksort    = '$linksort',
+                 description = '$description',
+                 author      = '".doSlash($txp_user)."'
+                "
             );
             if ($ok) {
                 $GLOBALS['ID'] = $_POST['id'] = $ok;
@@ -617,7 +642,7 @@ function link_multi_edit()
     $key = '';
 
     switch ($method) {
-        case 'delete' :
+        case 'delete':
             if (!has_privs('link.delete')) {
                 if (has_privs('link.delete.own')) {
                     $selected = safe_column("id", 'txp_link', "id IN (".join(',', $selected).") AND author = '".doSlash($txp_user)."'");
@@ -666,9 +691,12 @@ function link_multi_edit()
     if ($changed) {
         update_lastmod('link_updated', $changed);
 
-        link_list(gTxt(
-            ($method == 'delete' ? 'links_deleted' : 'link_updated'),
-            array(($method == 'delete' ? '{list}' : '{name}') => join(', ', $changed))));
+        link_list(
+            gTxt(
+                ($method == 'delete' ? 'links_deleted' : 'link_updated'),
+                array(($method == 'delete' ? '{list}' : '{name}') => join(', ', $changed))
+            )
+        );
 
         return;
     }

--- a/textpattern/include/txp_list.php
+++ b/textpattern/include/txp_list.php
@@ -140,7 +140,8 @@ function list_list($message = '', $post = '')
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
-    $search = new Filter($event,
+    $search = new Filter(
+        $event,
         array(
             'id' => array(
                 'column' => 'textpattern.ID',
@@ -216,12 +217,15 @@ function list_list($message = '', $post = '')
 
     echo n.tag(
         hed(gTxt('tab_list'), 1, array('class' => 'txp-heading')),
-        'div', array('class' => 'txp-layout-2col-cell-1'));
+        'div',
+        array('class' => 'txp-layout-2col-cell-1')
+    );
 
     $searchBlock =
         n.tag(
             $search->renderForm('list', $search_render_options),
-            'div', array(
+            'div',
+            array(
                 'class' => 'txp-layout-2col-cell-2',
                 'id'    => $event.'_control',
             )
@@ -230,17 +234,17 @@ function list_list($message = '', $post = '')
     $createBlock = array();
 
     if (has_privs('article.edit')) {
-        $createBlock[] =
-            n.tag(
-                sLink('article', '', gTxt('add_new_article'), 'txp-button'),
-                'div', array('class' => 'txp-control-panel')
-            );
+        $createBlock[] = n.tag(
+            sLink('article', '', gTxt('add_new_article'), 'txp-button'),
+            'div',
+            array('class' => 'txp-control-panel')
+        );
     }
 
     $contentBlockStart = n.tag_start('div', array(
-            'class' => 'txp-layout-1col',
-            'id'    => $event.'_container',
-        ));
+        'class' => 'txp-layout-1col',
+        'id'    => $event.'_container',
+    ));
 
     $createBlock = implode(n, $createBlock);
 
@@ -295,7 +299,7 @@ function list_list($message = '', $post = '')
         $show_authors = !has_single_author('textpattern', 'AuthorID');
 
         echo n.tag(
-                toggle_box('articles_detail'), 'div', array('class' => 'txp-list-options')).
+            toggle_box('articles_detail'), 'div', array('class' => 'txp-list-options')).
             n.tag_start('form', array(
                 'class'  => 'multi_edit_form',
                 'id'     => 'articles_form',
@@ -309,27 +313,28 @@ function list_list($message = '', $post = '')
             tr(
                 hCell(
                     fInput('checkbox', 'select_all', 0, '', '', '', '', '', 'select_all'),
-                        '', ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
+                    '',
+                    ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
                 ).
                 column_head(
                     'ID', 'id', 'list', true, $switch_dir, $crit, $search_method,
-                        (('id' == $sort) ? "$dir " : '').'txp-list-col-id'
+                    (('id' == $sort) ? "$dir " : '').'txp-list-col-id'
                 ).
                 column_head(
                     'title', 'title', 'list', true, $switch_dir, $crit, $search_method,
-                        (('title' == $sort) ? "$dir " : '').'txp-list-col-title'
+                    (('title' == $sort) ? "$dir " : '').'txp-list-col-title'
                 ).
                 column_head(
                     'posted', 'posted', 'list', true, $switch_dir, $crit, $search_method,
-                        (('posted' == $sort) ? "$dir " : '').'txp-list-col-created date'
+                    (('posted' == $sort) ? "$dir " : '').'txp-list-col-created date'
                 ).
                 column_head(
                     'article_modified', 'lastmod', 'list', true, $switch_dir, $crit, $search_method,
-                        (('lastmod' == $sort) ? "$dir " : '').'txp-list-col-lastmod date articles_detail'
+                    (('lastmod' == $sort) ? "$dir " : '').'txp-list-col-lastmod date articles_detail'
                 ).
                 column_head(
                     'expires', 'expires', 'list', true, $switch_dir, $crit, $search_method,
-                        (('expires' == $sort) ? "$dir " : '').'txp-list-col-expires date articles_detail'
+                    (('expires' == $sort) ? "$dir " : '').'txp-list-col-expires date articles_detail'
                 ).
                 column_head(
                     'section', 'section', 'list', true, $switch_dir, $crit, $search_method,
@@ -337,26 +342,26 @@ function list_list($message = '', $post = '')
                 ).
                 column_head(
                     'category1', 'category1', 'list', true, $switch_dir, $crit, $search_method,
-                        (('category1' == $sort) ? "$dir " : '').'txp-list-col-category1 category articles_detail'
+                    (('category1' == $sort) ? "$dir " : '').'txp-list-col-category1 category articles_detail'
                 ).
                 column_head(
                     'category2', 'category2', 'list', true, $switch_dir, $crit, $search_method,
-                        (('category2' == $sort) ? "$dir " : '').'txp-list-col-category2 category articles_detail'
+                    (('category2' == $sort) ? "$dir " : '').'txp-list-col-category2 category articles_detail'
                 ).
                 column_head(
                     'status', 'status', 'list', true, $switch_dir, $crit, $search_method,
-                        (('status' == $sort) ? "$dir " : '').'txp-list-col-status'
+                    (('status' == $sort) ? "$dir " : '').'txp-list-col-status'
                 ).
                 (
                     $show_authors
                     ? column_head('author', 'author', 'list', true, $switch_dir, $crit, $search_method,
-                        (('author' == $sort) ? "$dir " : '').'txp-list-col-author name')
+                      (('author' == $sort) ? "$dir " : '').'txp-list-col-author name')
                     : ''
                 ).
                 (
                     $use_comments == 1
                     ? column_head('comments', 'comments', 'list', true, $switch_dir, $crit, $search_method,
-                        (('comments' == $sort) ? "$dir " : '').'txp-list-col-comments articles_detail')
+                      (('comments' == $sort) ? "$dir " : '').'txp-list-col-comments articles_detail')
                     : ''
                 )
             ).
@@ -426,68 +431,66 @@ function list_list($message = '', $post = '')
                 tag($comment_status, 'span', array('class' => 'comments-status')).' '.
                 tag($comments, 'span', array('class' => 'comments-manage'));
 
-            echo tr(
-                td(
-                    (
+            echo
+                tr(
+                    td(
                         (
-                            ($a['Status'] >= STATUS_LIVE and has_privs('article.edit.published'))
-                            or ($a['Status'] >= STATUS_LIVE and $AuthorID === $txp_user and has_privs('article.edit.own.published'))
-                            or ($a['Status'] < STATUS_LIVE and has_privs('article.edit'))
-                            or ($a['Status'] < STATUS_LIVE and $AuthorID === $txp_user and has_privs('article.edit.own'))
+                            (
+                                ($a['Status'] >= STATUS_LIVE and has_privs('article.edit.published'))
+                                or ($a['Status'] >= STATUS_LIVE and $AuthorID === $txp_user and has_privs('article.edit.own.published'))
+                                or ($a['Status'] < STATUS_LIVE and has_privs('article.edit'))
+                                or ($a['Status'] < STATUS_LIVE and $AuthorID === $txp_user and has_privs('article.edit.own'))
+                            )
+                        ? fInput('checkbox', 'selected[]', $ID, 'checkbox')
+                        : ''
+                        ),
+                        '',
+                        'txp-list-col-multi-edit'
+                    ).
+                    hCell(
+                        eLink('article', 'edit', 'ID', $ID, $ID).
+                        span(
+                            sp.span('&#124;', array('role' => 'separator')).
+                            sp.href(gTxt('view'), $view_url),
+                            array('class' => 'txp-option-link articles_detail')
+                        ),
+                        '',
+                        array(
+                            'class' => 'txp-list-col-id',
+                            'scope' => 'row',
                         )
-                    ? fInput('checkbox', 'selected[]', $ID, 'checkbox')
-                    : ''
-                    ), '', 'txp-list-col-multi-edit'
-                ).
-                hCell(
-                    eLink('article', 'edit', 'ID', $ID, $ID).
-                    span(
-                        sp.span('&#124;', array('role' => 'separator')).
-                        sp.href(gTxt('view'), $view_url),
-                        array('class' => 'txp-option-link articles_detail')
-                    ), '', array(
-                        'class' => 'txp-list-col-id',
-                        'scope' => 'row',
+                    ).
+                    td($Title, '', 'txp-list-col-title').
+                    td(gTime($posted), '', 'txp-list-col-created date'.($posted < time() ? '' : ' unpublished')).
+                    td(
+                        gTime($lastmod),
+                        '',
+                        'txp-list-col-lastmod date articles_detail'.($posted === $lastmod ? ' not-modified' : '')
+                    ).
+                    td(($expires ? gTime($expires) : ''), '', 'txp-list-col-expires date articles_detail').
+                    td(span(txpspecialchars($section_title), array('title' => $Section)), '', 'txp-list-col-section'.$vs).
+                    td($Category1, '', 'txp-list-col-category1 category articles_detail'.$vc[1]).
+                    td($Category2, '', 'txp-list-col-category2 category articles_detail'.$vc[2]).
+                    td(
+                        href($Status, $view_url, join_atts(array('title' => gTxt('view')), TEXTPATTERN_STRIP_EMPTY)),
+                        '',
+                        'txp-list-col-status'
+                    ).
+                    (
+                        $show_authors
+                        ? td(span(txpspecialchars($RealName), array('title' => $AuthorID)), '', 'txp-list-col-author name')
+                        : ''
+                    ).
+                    (
+                        $use_comments
+                        ? td($comments, '', 'txp-list-col-comments articles_detail')
+                        : ''
                     )
-                ).
-                td(
-                    $Title, '', 'txp-list-col-title'
-                ).
-                td(
-                    gTime($posted), '', 'txp-list-col-created date'.($posted < time() ? '' : ' unpublished')
-                ).
-                td(
-                    gTime($lastmod), '', 'txp-list-col-lastmod date articles_detail'.($posted === $lastmod ? ' not-modified' : '')
-                ).
-                td(
-                    ($expires ? gTime($expires) : ''), '', 'txp-list-col-expires date articles_detail'
-                ).
-                td(
-                    span(txpspecialchars($section_title), array('title' => $Section)), '', 'txp-list-col-section'.$vs
-                ).
-                td(
-                    $Category1, '', 'txp-list-col-category1 category articles_detail'.$vc[1]
-                ).
-                td(
-                    $Category2, '', 'txp-list-col-category2 category articles_detail'.$vc[2]
-                ).
-                td(
-                    href($Status, $view_url, join_atts(array('title' => gTxt('view')), TEXTPATTERN_STRIP_EMPTY)), '', 'txp-list-col-status'
-                ).
-                (
-                    $show_authors
-                    ? td(span(txpspecialchars($RealName), array('title' => $AuthorID)), '', 'txp-list-col-author name')
-                    : ''
-                ).
-                (
-                    $use_comments
-                    ? td($comments, '', 'txp-list-col-comments articles_detail')
-                    : ''
-                )
-            );
+                );
         }
 
-        echo n.tag_end('tbody').
+        echo
+            n.tag_end('tbody').
             n.tag_end('table').
             n.tag_end('div').
             list_multiedit_form($page, $sort, $dir, $crit, $search_method).
@@ -500,7 +503,7 @@ function list_list($message = '', $post = '')
             pageby_form('list', $article_list_pageby).
             nav_form('list', $page, $numPages, $sort, $dir, $crit, $search_method, $total, $limit).
             n.tag_end('div');
-    }
+        }
 
     echo n.tag_end('div');
 }
@@ -679,8 +682,7 @@ function list_multi_edit()
     );
 
     foreach ($selected as $item) {
-        if (
-            ($item['Status'] >= STATUS_LIVE && has_privs('article.edit.published')) ||
+        if (($item['Status'] >= STATUS_LIVE && has_privs('article.edit.published')) ||
             ($item['Status'] >= STATUS_LIVE && $item['AuthorID'] === $txp_user && has_privs('article.edit.own.published')) ||
             ($item['Status'] < STATUS_LIVE && has_privs('article.edit')) ||
             ($item['Status'] < STATUS_LIVE && $item['AuthorID'] === $txp_user && has_privs('article.edit.own'))

--- a/textpattern/include/txp_log.php
+++ b/textpattern/include/txp_log.php
@@ -122,7 +122,8 @@ function log_list($message = '')
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
-    $search = new Filter($event,
+    $search = new Filter(
+        $event,
         array(
             'ip' => array(
                 'column' => 'txp_log.ip',
@@ -164,12 +165,15 @@ function log_list($message = '')
 
     echo n.tag(
         hed(gTxt('tab_logs'), 1, array('class' => 'txp-heading')),
-        'div', array('class' => 'txp-layout-2col-cell-1'));
+        'div',
+        array('class' => 'txp-layout-2col-cell-1')
+    );
 
     $searchBlock =
         n.tag(
             $search->renderForm('log_list', $search_render_options),
-            'div', array(
+            'div',
+            array(
                 'class' => 'txp-layout-2col-cell-2',
                 'id'    => $event.'_control',
             )
@@ -216,8 +220,12 @@ function log_list($message = '')
     );
 
     if ($rs) {
-        echo n.tag(
-                toggle_box('log_detail'), 'div', array('class' => 'txp-list-options')).
+        echo
+            n.tag(
+                toggle_box('log_detail'),
+                'div',
+                array('class' => 'txp-list-options')
+            ).
             n.tag_start('form', array(
                 'class'  => 'multi_edit_form',
                 'id'     => 'log_form',
@@ -231,35 +239,36 @@ function log_list($message = '')
             tr(
                 hCell(
                     fInput('checkbox', 'select_all', 0, '', '', '', '', '', 'select_all'),
-                        '', ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
+                    '',
+                    ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
                 ).
                 column_head(
                     'time', 'time', 'log', true, $switch_dir, $crit, $search_method,
-                        (('time' == $sort) ? "$dir " : '').'txp-list-col-time'
+                    (('time' == $sort) ? "$dir " : '').'txp-list-col-time'
                 ).
                 column_head(
                     'IP', 'ip', 'log', true, $switch_dir, $crit, $search_method,
-                        (('ip' == $sort) ? "$dir " : '').'txp-list-col-ip'
+                    (('ip' == $sort) ? "$dir " : '').'txp-list-col-ip'
                 ).
                 column_head(
                     'host', 'host', 'log', true, $switch_dir, $crit, $search_method,
-                        (('host' == $sort) ? "$dir " : '').'txp-list-col-host log_detail'
+                    (('host' == $sort) ? "$dir " : '').'txp-list-col-host log_detail'
                 ).
                 column_head(
                     'page', 'page', 'log', true, $switch_dir, $crit, $search_method,
-                        (('page' == $sort) ? "$dir " : '').'txp-list-col-page'
+                    (('page' == $sort) ? "$dir " : '').'txp-list-col-page'
                 ).
                 column_head(
                     'referrer', 'refer', 'log', true, $switch_dir, $crit, $search_method,
-                        (('refer' == $sort) ? "$dir " : '').'txp-list-col-refer'
+                    (('refer' == $sort) ? "$dir " : '').'txp-list-col-refer'
                 ).
                 column_head(
                     'method', 'method', 'log', true, $switch_dir, $crit, $search_method,
-                        (('method' == $sort) ? "$dir " : '').'txp-list-col-method log_detail'
+                    (('method' == $sort) ? "$dir " : '').'txp-list-col-method log_detail'
                 ).
                 column_head(
                     'status', 'status', 'log', true, $switch_dir, $crit, $search_method,
-                        (('status' == $sort) ? "$dir " : '').'txp-list-col-status log_detail'
+                    (('status' == $sort) ? "$dir " : '').'txp-list-col-status log_detail'
                 )
             ).
             n.tag_end('thead').
@@ -284,33 +293,17 @@ function log_list($message = '')
             }
 
             echo tr(
-                td(
-                    fInput('checkbox', 'selected[]', $log_id), '', 'txp-list-col-multi-edit'
-                ).
-                hCell(
-                    gTime($log_uTime), '', ' class="txp-list-col-time" scope="row"'
-                ).
-                td(
-                    href(txpspecialchars($log_ip), 'https://whois.domaintools.com/'.rawurlencode($log_ip), array(
+                td(fInput('checkbox', 'selected[]', $log_id), '', 'txp-list-col-multi-edit').
+                hCell(gTime($log_uTime), '', ' class="txp-list-col-time" scope="row"').
+                td(href(txpspecialchars($log_ip), 'https://whois.domaintools.com/'.rawurlencode($log_ip), array(
                         'rel'    => 'external',
                         'target' => '_blank',
-                    )), '', 'txp-list-col-ip'
-                ).
-                td(
-                    txpspecialchars($log_host), '', 'txp-list-col-host log_detail'
-                ).
-                td(
-                    $log_page, '', 'txp-list-col-page'
-                ).
-                td(
-                    $log_refer, '', 'txp-list-col-refer'
-                ).
-                td(
-                    txpspecialchars($log_method), '', 'txp-list-col-method log_detail'
-                ).
-                td(
-                    $log_status, '', 'txp-list-col-status log_detail'
-                )
+                    )), '', 'txp-list-col-ip').
+                td(txpspecialchars($log_host), '', 'txp-list-col-host log_detail').
+                td($log_page, '', 'txp-list-col-page').
+                td($log_refer, '', 'txp-list-col-refer').
+                td(txpspecialchars($log_method), '', 'txp-list-col-method log_detail').
+                td($log_status, '', 'txp-list-col-status log_detail')
             );
         }
 

--- a/textpattern/include/txp_page.php
+++ b/textpattern/include/txp_page.php
@@ -123,23 +123,32 @@ function page_edit($message = '')
 
     // Pages code columm.
 
-    echo n.tag(
-        hed(gTxt('tab_pages'), 1, array('class' => 'txp-heading')).
-        form(
-            $titleblock.
-            inputLabel(
-                'html',
-                '<textarea class="code" id="html" name="html" cols="'.INPUT_LARGE.'" rows="'.TEXTAREA_HEIGHT_LARGE.'" dir="ltr">'.txpspecialchars($html).'</textarea>',
-                'page_code',
-                array('', 'instructions_page_code'),
-                array('class' => 'txp-form-field')
-            ), '', '', 'post', '', '', 'page_form'),
-        'div', array(
-            'class' => 'txp-layout-4col-cell-1-2-3',
-            'id'    => 'main_content',
-            'role'  => 'region',
-        )
-    );
+    echo
+        n.tag(
+            hed(gTxt('tab_pages'), 1, array('class' => 'txp-heading')).
+            form(
+                $titleblock.
+                inputLabel(
+                    'html',
+                    '<textarea class="code" id="html" name="html" cols="'.INPUT_LARGE.'" rows="'.TEXTAREA_HEIGHT_LARGE.'" dir="ltr">'.txpspecialchars($html).'</textarea>',
+                    'page_code',
+                    array('', 'instructions_page_code'),
+                    array('class' => 'txp-form-field')
+                ),
+                '',
+                '',
+                'post',
+                '',
+                '',
+                'page_form'
+            ),
+            'div',
+            array(
+                'class' => 'txp-layout-4col-cell-1-2-3',
+                'id'    => 'main_content',
+                'role'  => 'region',
+            )
+        );
 
     // Pages create/switcher column.
 
@@ -159,7 +168,8 @@ function page_edit($message = '')
             'method' => 'post',
             'value'  =>  gTxt('save'),
             'form'   => 'page_form',
-        )), ' class="txp-save"'
+        )),
+        ' class="txp-save"'
     ).
     graf(
         sLink('page', 'page_new', '<span class="ui-icon ui-extra-icon-new-document"></span> '.gTxt('create_new_page'), 'txp-new').
@@ -170,7 +180,8 @@ function page_edit($message = '')
     echo n.tag(
         $buttons.
         page_list($name).n,
-        'div', array(
+        'div',
+        array(
             'class' => 'txp-layout-4col-cell-4alt',
             'id'    => 'content_switcher',
             'role'  => 'region',

--- a/textpattern/include/txp_plugin.php
+++ b/textpattern/include/txp_plugin.php
@@ -91,9 +91,12 @@ function plugin_list($message = '')
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
-    echo n.tag(
-        hed(gTxt('tab_plugins'), 1, array('class' => 'txp-heading')),
-        'div', array('class' => 'txp-layout-2col-cell-1')).
+    echo
+        n.tag(
+            hed(gTxt('tab_plugins'), 1, array('class' => 'txp-heading')),
+            'div',
+            array('class' => 'txp-layout-2col-cell-1')
+        ).
         n.tag_start('div', array(
             'class' => 'txp-layout-1col',
             'id'    => $event.'_container',
@@ -121,38 +124,35 @@ function plugin_list($message = '')
             tr(
                 hCell(
                     fInput('checkbox', 'select_all', 0, '', '', '', '', '', 'select_all'),
-                        '', ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
+                    '',
+                    ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
                 ).
                 column_head(
                     'plugin', 'name', 'plugin', true, $switch_dir, '', '',
-                        (('name' == $sort) ? "$dir " : '').'txp-list-col-name'
+                    (('name' == $sort) ? "$dir " : '').'txp-list-col-name'
                 ).
                 column_head(
                     'author', 'author', 'plugin', true, $switch_dir, '', '',
-                        (('author' == $sort) ? "$dir " : '').'txp-list-col-author'
+                    (('author' == $sort) ? "$dir " : '').'txp-list-col-author'
                 ).
                 column_head(
                     'version', 'version', 'plugin', true, $switch_dir, '', '',
-                        (('version' == $sort) ? "$dir " : '').'txp-list-col-version'
+                    (('version' == $sort) ? "$dir " : '').'txp-list-col-version'
                 ).
                 column_head(
                     'plugin_modified', 'modified', 'plugin', true, $switch_dir, '', '',
-                        (('modified' == $sort) ? "$dir " : '').'txp-list-col-modified'
+                    (('modified' == $sort) ? "$dir " : '').'txp-list-col-modified'
                 ).
-                hCell(gTxt(
-                    'description'), '', ' class="txp-list-col-description" scope="col"'
-                ).
+                hCell(gTxt('description'), '', ' class="txp-list-col-description" scope="col"').
                 column_head(
                     'active', 'status', 'plugin', true, $switch_dir, '', '',
-                        (('status' == $sort) ? "$dir " : '').'txp-list-col-status'
+                    (('status' == $sort) ? "$dir " : '').'txp-list-col-status'
                 ).
                 column_head(
                     'order', 'load_order', 'plugin', true, $switch_dir, '', '',
-                        (('load_order' == $sort) ? "$dir " : '').'txp-list-col-load-order'
+                    (('load_order' == $sort) ? "$dir " : '').'txp-list-col-load-order'
                 ).
-                hCell(
-                    gTxt('manage'), '',  ' class="txp-list-col-manage" scope="col"'
-                )
+                hCell(gTxt('manage'), '',  ' class="txp-list-col-manage" scope="col"')
             ).
             n.tag_end('thead').
             n.tag_start('tbody');
@@ -208,47 +208,30 @@ function plugin_list($message = '')
             $manage_items = ($manage) ? join($manage) : '-';
             $edit_url = eLink('plugin', 'plugin_edit', 'name', $name, $name);
 
-            echo tr(
-                td(
-                    fInput('checkbox', 'selected[]', $name), '', 'txp-list-col-multi-edit'
-                ).
-                hCell(
-                    $edit_url, '', ' class="txp-list-col-name" scope="row"'
-                ).
-                td(
-                    href($author, $a['author_uri'], array('rel' => 'external')), '', 'txp-list-col-author'
-                ).
-                td(
-                    $version, '', 'txp-list-col-version'
-                ).
-                td(
-                    ($modified ? span(gTxt('yes'), array('class' => 'warning')) : ''), '', 'txp-list-col-modified'
-                ).
-                td(
-                    $description, '', 'txp-list-col-description'
-                ).
-                td(
-                    status_link($status, $name, yes_no($status)), '', 'txp-list-col-status'
-                ).
-                td(
-                    $load_order, '', 'txp-list-col-load-order'
-                ).
-                td(
-                    $manage_items, '', 'txp-list-col-manage'
-                ),
-                $status ? ' class="active"' : ''
-            );
+            echo
+                tr(
+                    td(fInput('checkbox', 'selected[]', $name), '', 'txp-list-col-multi-edit').
+                    hCell($edit_url, '', ' class="txp-list-col-name" scope="row"').
+                    td(href($author, $a['author_uri'], array('rel' => 'external')), '', 'txp-list-col-author').
+                    td($version, '', 'txp-list-col-version').
+                    td(($modified ? span(gTxt('yes'), array('class' => 'warning')) : ''), '', 'txp-list-col-modified').
+                    td($description, '', 'txp-list-col-description').
+                    td(status_link($status, $name, yes_no($status)), '', 'txp-list-col-status').
+                    td($load_order, '', 'txp-list-col-load-order').
+                    td($manage_items, '', 'txp-list-col-manage'),
+                    $status ? ' class="active"' : ''
+                );
 
             unset($name, $page, $deletelink);
         }
 
         echo
-            n.tag_end('tbody').
-            n.tag_end('table').
-            n.tag_end('div').
-            plugin_multiedit_form('', $sort, $dir, '', '').
-            tInput().
-            n.tag_end('form');
+        n.tag_end('tbody').
+        n.tag_end('table').
+        n.tag_end('div').
+        plugin_multiedit_form('', $sort, $dir, '', '').
+        tInput().
+        n.tag_end('form');
     }
 
     echo n.tag_end('div');
@@ -315,17 +298,24 @@ function plugin_edit_form($name = '')
     $thing = ($code) ? $code : '';
 
     return
-        form(
-            hed(gTxt('edit_plugin', array('{name}' => $name)), 2).
-            graf('<textarea class="code" id="plugin_code" name="code" cols="'.INPUT_XLARGE.'" rows="'.TEXTAREA_HEIGHT_LARGE.'" dir="ltr">'.txpspecialchars($thing).'</textarea>', ' class="edit-plugin-code"').
-            graf(
-                sLink('plugin', '', gTxt('cancel'), 'txp-button').
-                fInput('submit', '', gTxt('save'), 'publish'),
-                array('class' => 'txp-edit-actions')
-            ).
-            eInput('plugin').
-            sInput('plugin_save').
-            hInput('name', $name), '', '', 'post', '', '', 'plugin_details');
+    form(
+        hed(gTxt('edit_plugin', array('{name}' => $name)), 2).
+        graf('<textarea class="code" id="plugin_code" name="code" cols="'.INPUT_XLARGE.'" rows="'.TEXTAREA_HEIGHT_LARGE.'" dir="ltr">'.txpspecialchars($thing).'</textarea>', ' class="edit-plugin-code"').
+        graf(
+            sLink('plugin', '', gTxt('cancel'), 'txp-button').
+            fInput('submit', '', gTxt('save'), 'publish'),
+            array('class' => 'txp-edit-actions')
+        ).
+        eInput('plugin').
+        sInput('plugin_save').
+        hInput('name', $name),
+        '',
+        '',
+        'post',
+        '',
+        '',
+        'plugin_details'
+    );
 }
 
 /**
@@ -435,16 +425,23 @@ function plugin_verify()
                 );
 
                 pagetop(gTxt('verify_plugin'));
-                echo form(
-                    hed(gTxt('previewing_plugin'), 2).
-                    tag($source, 'div', ' class="code" id="preview-plugin" dir="ltr"').
-                    hed(gTxt('plugin_help').':', 2).
-                    tag($help_source, 'div', ' class="code" id="preview-help" dir="ltr"').
-                    $sub.
-                    sInput('plugin_install').
-                    eInput('plugin').
-                    hInput('plugin64', $plugin_encoded), '', '', 'post', 'plugin-info', '', 'plugin_preview'
-                );
+                echo
+                    form(
+                        hed(gTxt('previewing_plugin'), 2).
+                        tag($source, 'div', ' class="code" id="preview-plugin" dir="ltr"').
+                        hed(gTxt('plugin_help').':', 2).
+                        tag($help_source, 'div', ' class="code" id="preview-help" dir="ltr"').
+                        $sub.
+                        sInput('plugin_install').
+                        eInput('plugin').
+                        hInput('plugin64', $plugin_encoded),
+                        '',
+                        '',
+                        'post',
+                        'plugin-info',
+                        '',
+                        'plugin_preview'
+                    );
 
                 return;
             }
@@ -493,35 +490,37 @@ function plugin_install()
 
                 if ($exists) {
                     $rs = safe_update(
-                       'txp_plugin',
-                        "type        = $type,
-                        author       = '".doSlash($author)."',
-                        author_uri   = '".doSlash($author_uri)."',
-                        version      = '".doSlash($version)."',
-                        description  = '".doSlash($description)."',
-                        help         = '".doSlash($help)."',
-                        code         = '".doSlash($code)."',
-                        code_restore = '".doSlash($code)."',
-                        code_md5     = '".doSlash($md5)."',
-                        flags        = $flags",
+                        'txp_plugin',
+                        "type         = $type,
+                         author       = '".doSlash($author)."',
+                         author_uri   = '".doSlash($author_uri)."',
+                         version      = '".doSlash($version)."',
+                         description  = '".doSlash($description)."',
+                         help         = '".doSlash($help)."',
+                         code         = '".doSlash($code)."',
+                         code_restore = '".doSlash($code)."',
+                         code_md5     = '".doSlash($md5)."',
+                         flags        = $flags
+                        ",
                         "name        = '".doSlash($name)."'"
                     );
                 } else {
                     $rs = safe_insert(
-                       'txp_plugin',
-                       "name         = '".doSlash($name)."',
-                        status       = 0,
-                        type         = $type,
-                        author       = '".doSlash($author)."',
-                        author_uri   = '".doSlash($author_uri)."',
-                        version      = '".doSlash($version)."',
-                        description  = '".doSlash($description)."',
-                        help         = '".doSlash($help)."',
-                        code         = '".doSlash($code)."',
-                        code_restore = '".doSlash($code)."',
-                        code_md5     = '".doSlash($md5)."',
-                        load_order   = '".$order."',
-                        flags        = $flags"
+                        'txp_plugin',
+                        "name         = '".doSlash($name)."',
+                         status       = 0,
+                         type         = $type,
+                         author       = '".doSlash($author)."',
+                         author_uri   = '".doSlash($author_uri)."',
+                         version      = '".doSlash($version)."',
+                         description  = '".doSlash($description)."',
+                         help         = '".doSlash($help)."',
+                         code         = '".doSlash($code)."',
+                         code_restore = '".doSlash($code)."',
+                         code_md5     = '".doSlash($md5)."',
+                         load_order   = '".$order."',
+                         flags        = $flags
+                        "
                     );
                 }
 
@@ -573,8 +572,14 @@ function plugin_form()
         '<textarea class="code" id="plugin-install" name="plugin" cols="'.INPUT_LARGE.'" rows="'.TEXTAREA_HEIGHT_SMALL.'" dir="ltr"></textarea>'.
         fInput('submit', 'install_new', gTxt('upload')).
         eInput('plugin').
-        sInput('plugin_verify')
-        , '', '', 'post', 'plugin-data', '', 'plugin_install_form');
+        sInput('plugin_verify'),
+        '',
+        '',
+        'post',
+        'plugin-data',
+        '',
+        'plugin_install_form'
+    );
 }
 
 /**

--- a/textpattern/include/txp_prefs.php
+++ b/textpattern/include/txp_prefs.php
@@ -204,24 +204,27 @@ function prefs_list($message = '')
                 if ($last_event !== null) {
                     $build[] = tag(
                         hed(gTxt($last_event), 2, array('id' => 'prefs_group_'.$last_event.'-label')).
-                        join(n, $out)
-                        , 'section', array(
+                        join(n, $out),
+                        'section',
+                        array(
                             'class'           => 'txp-prefs-group',
                             'id'              => 'prefs_group_'.$last_event,
                             'aria-labelledby' => 'prefs_group_'.$last_event.'-label',
                         )
                     );
 
-                    $groupOut[] = n.tag(href(
+                    $groupOut[] = n.tag(
+                        href(
                             gTxt($last_event),
                             '#prefs_group_'.$last_event,
                             array(
                                 'data-txp-pane'  => $last_event,
                                 'data-txp-token' => md5($last_event.'prefs'.form_token().get_pref('blog_uid')),
-                            )),
-                        'li', array(
-                            'class' => (($last_event === $selected) ? 'ui-tabs-active ui-state-active' : '')
-                            ));
+                            )
+                        ),
+                        'li',
+                        array('class' => (($last_event === $selected) ? 'ui-tabs-active ui-state-active' : ''))
+                    );
                 }
 
                 if ($last_event === $selected) {
@@ -273,24 +276,27 @@ function prefs_list($message = '')
     } else {
         $build[] = tag(
             hed(gTxt($last_event), 2, array('id' => 'prefs_group_'.$last_event.'-label')).
-            join(n, $out)
-            , 'section', array(
+            join(n, $out),
+            'section',
+            array(
                 'class'           => 'txp-prefs-group',
                 'id'              => 'prefs_group_'.$last_event,
                 'aria-labelledby' => 'prefs_group_'.$last_event.'-label',
             )
         );
 
-        $groupOut[] = n.tag(href(
+        $groupOut[] = n.tag(
+            href(
                 gTxt($last_event),
                 '#prefs_group_'.$last_event,
                 array(
                     'data-txp-pane'  => $last_event,
                     'data-txp-token' => md5($last_event.'prefs'.form_token().get_pref('blog_uid')),
-                )),
-            'li', array(
-                'class' => (($last_event === $selected) ? 'ui-tabs-active ui-state-active' : '')
-                )).n;
+                )
+            ),
+            'li',
+            array('class' => (($last_event === $selected) ? 'ui-tabs-active ui-state-active' : ''))
+        ).n;
 
         if ($last_event === $selected) {
             $tabActive = $tabCount - 1;
@@ -750,8 +756,7 @@ function themename($name, $val)
     }
     asort($vals, SORT_STRING);
 
-    return pluggable_ui('prefs_ui', 'theme_name',
-        selectInput($name, $vals, $val, '', '', $name));
+    return pluggable_ui('prefs_ui', 'theme_name', selectInput($name, $vals, $val, '', '', $name));
 }
 
 /**

--- a/textpattern/include/txp_section.php
+++ b/textpattern/include/txp_section.php
@@ -127,7 +127,8 @@ function sec_section_list($message = '')
 
     $switch_dir = ($dir == 'desc') ? 'asc' : 'desc';
 
-    $search = new Filter($event,
+    $search = new Filter(
+        $event,
         array(
             'name' => array(
                 'column' => 'txp_section.name',
@@ -177,14 +178,18 @@ function sec_section_list($message = '')
 
     $total = safe_count('txp_section', $criteria);
 
-    echo n.tag(
-        hed(gTxt('tab_sections'), 1, array('class' => 'txp-heading')),
-        'div', array('class' => 'txp-layout-2col-cell-1'));
+    echo
+        n.tag(
+            hed(gTxt('tab_sections'), 1, array('class' => 'txp-heading')),
+            'div',
+            array('class' => 'txp-layout-2col-cell-1')
+        );
 
     $searchBlock =
         n.tag(
             $search->renderForm('sec_section', $search_render_options),
-            'div', array(
+            'div',
+            array(
                 'class' => 'txp-layout-2col-cell-2',
                 'id'    => $event.'_control',
             )
@@ -193,24 +198,24 @@ function sec_section_list($message = '')
     $createBlock = array();
 
     if (has_privs('section.edit')) {
-        $createBlock[] =
-            n.tag(
-                sLink('section', 'section_edit', gTxt('create_section'), 'txp-button').
-                n.tag_start('form', array(
-                    'class'  => 'async',
-                    'id'     => 'default_section_form',
-                    'name'   => 'default_section_form',
-                    'method' => 'post',
-                    'action' => 'index.php',
-                )).
-                tag(gTxt('default_write_section'), 'label', array('for' => 'default_section')).
-                popHelp('section_default').
-                section_select_list().
-                eInput('section').
-                sInput('section_set_default').
-                n.tag_end('form'),
-                'div', array('class' => 'txp-control-panel')
-            );
+        $createBlock[] = n.tag(
+            sLink('section', 'section_edit', gTxt('create_section'), 'txp-button').
+            n.tag_start('form', array(
+                'class'  => 'async',
+                'id'     => 'default_section_form',
+                'name'   => 'default_section_form',
+                'method' => 'post',
+                'action' => 'index.php',
+            )).
+            tag(gTxt('default_write_section'), 'label', array('for' => 'default_section')).
+            popHelp('section_default').
+            section_select_list().
+            eInput('section').
+            sInput('section_set_default').
+            n.tag_end('form'),
+            'div',
+            array('class' => 'txp-control-panel')
+        );
     }
 
     $contentBlockStart = n.tag_start('div', array(
@@ -249,8 +254,8 @@ function sec_section_list($message = '')
     );
 
     if ($rs) {
-        echo n.tag(
-                toggle_box('section_detail'), 'div', array('class' => 'txp-list-options')).
+        echo
+            n.tag(toggle_box('section_detail'), 'div', array('class' => 'txp-list-options')).
             n.tag_start('form', array(
                 'class'  => 'multi_edit_form',
                 'id'     => 'section_form',
@@ -264,19 +269,20 @@ function sec_section_list($message = '')
             tr(
                 hCell(
                     fInput('checkbox', 'select_all', 0, '', '', '', '', '', 'select_all'),
-                        '', ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
+                    '',
+                    ' class="txp-list-col-multi-edit" scope="col" title="'.gTxt('toggle_all_selected').'"'
                 ).
                 column_head(
                     'name', 'name', 'section', true, $switch_dir, $crit, $search_method,
-                        (('name' == $sort) ? "$dir " : '').'txp-list-col-name'
+                    (('name' == $sort) ? "$dir " : '').'txp-list-col-name'
                 ).
                 column_head(
                     'title', 'title', 'section', true, $switch_dir, $crit, $search_method,
-                        (('title' == $sort) ? "$dir " : '').'txp-list-col-title'
+                    (('title' == $sort) ? "$dir " : '').'txp-list-col-title'
                 ).
                 column_head(
                     'page', 'page', 'section', true, $switch_dir, $crit, $search_method,
-                        (('page' == $sort) ? "$dir " : '').'txp-list-col-page'
+                    (('page' == $sort) ? "$dir " : '').'txp-list-col-page'
                 ).
                 column_head(
                     'css', 'css', 'section', true, $switch_dir, $crit, $search_method,
@@ -284,19 +290,19 @@ function sec_section_list($message = '')
                 ).
                 column_head(
                     'on_front_page', 'on_frontpage', 'section', true, $switch_dir, $crit, $search_method,
-                        (('on_frontpage' == $sort) ? "$dir " : '').'txp-list-col-frontpage section_detail'
+                    (('on_frontpage' == $sort) ? "$dir " : '').'txp-list-col-frontpage section_detail'
                 ).
                 column_head(
                     'syndicate', 'in_rss', 'section', true, $switch_dir, $crit, $search_method,
-                        (('in_rss' == $sort) ? "$dir " : '').'txp-list-col-syndicate section_detail'
+                    (('in_rss' == $sort) ? "$dir " : '').'txp-list-col-syndicate section_detail'
                 ).
                 column_head(
                     'include_in_search', 'searchable', 'section', true, $switch_dir, $crit, $search_method,
-                        (('searchable' == $sort) ? "$dir " : '').'txp-list-col-searchable section_detail'
+                    (('searchable' == $sort) ? "$dir " : '').'txp-list-col-searchable section_detail'
                 ).
                 column_head(
                     'articles', 'article_count', 'section', true, $switch_dir, $crit, $search_method,
-                        (('article_count' == $sort) ? "$dir " : '').'txp-list-col-article_count section_detail'
+                    (('article_count' == $sort) ? "$dir " : '').'txp-list-col-article_count section_detail'
                 )
             ).
             n.tag_end('thead').
@@ -360,49 +366,35 @@ function sec_section_list($message = '')
                 'name'  => $sec_css,
             ), array('title' => gTxt('edit')));
 
-            echo tr(
-                td(
-                    fInput('checkbox', 'selected[]', $sec_name), '', 'txp-list-col-multi-edit'
-                ).
-                hCell(
-                    href(
-                        txpspecialchars($sec_name), $edit_url, array('title' => gTxt('edit'))
+            echo
+                tr(
+                    td(fInput('checkbox', 'selected[]', $sec_name), '', 'txp-list-col-multi-edit').
+                    hCell(
+                        href(txpspecialchars($sec_name), $edit_url, array('title' => gTxt('edit'))).
+                        span(
+                            sp.span('&#124;', array('role' => 'separator')).
+                            sp.href(gTxt('view'), pagelinkurl(array('s' => $sec_name))),
+                            array('class' => 'txp-option-link section_detail')
+                        ),
+                        '',
+                        array(
+                            'class' => 'txp-list-col-name',
+                            'scope' => 'row',
+                        )
                     ).
-                    span(
-                        sp.span('&#124;', array('role' => 'separator')).
-                        sp.href(gTxt('view'), pagelinkurl(array('s' => $sec_name))),
-                        array('class' => 'txp-option-link section_detail')
-                    ), '', array(
-                        'class' => 'txp-list-col-name',
-                        'scope' => 'row',
-                    )
-                ).
-                td(
-                    txpspecialchars($sec_title), '', 'txp-list-col-title'
-                ).
-                td(
-                    $sec_page, '', 'txp-list-col-page'
-                ).
-                td(
-                    $sec_css, '', 'txp-list-col-style'
-                ).
-                td(
-                    $sec_on_frontpage, '', 'txp-list-col-frontpage section_detail'
-                ).
-                td(
-                    $sec_in_rss, '', 'txp-list-col-syndicate section_detail'
-                ).
-                td(
-                    $sec_searchable, '', 'txp-list-col-searchable section_detail'
-                ).
-                td(
-                    $articles, '', 'txp-list-col-article_count section_detail'
-                ),
-                array('id' => 'txp_section_'.$sec_name)
-            );
+                    td(txpspecialchars($sec_title), '', 'txp-list-col-title').
+                    td($sec_page, '', 'txp-list-col-page').
+                    td($sec_css, '', 'txp-list-col-style').
+                    td($sec_on_frontpage, '', 'txp-list-col-frontpage section_detail').
+                    td($sec_in_rss, '', 'txp-list-col-syndicate section_detail').
+                    td($sec_searchable, '', 'txp-list-col-searchable section_detail').
+                    td($articles, '', 'txp-list-col-article_count section_detail'),
+                    array('id' => 'txp_section_'.$sec_name)
+                );
         }
 
-        echo n.tag_end('tbody').
+        echo
+            n.tag_end('tbody').
             n.tag_end('table').
             n.tag_end('div').
             section_multiedit_form($page, $sort, $dir, $crit, $search_method).
@@ -485,52 +477,70 @@ function section_edit()
     if ($is_default_section) {
         $out[] = hInput('name', 'default');
     } else {
-        $out[] = inputLabel(
-                'section_name',
-                fInput('text', 'name', $sec_name, '', '', '', INPUT_REGULAR, '', 'section_name'),
-                'section_name', '', array('class' => 'txp-form-field edit-section-name')
-            ).
-            inputLabel(
-                'section_title',
-                fInput('text', 'title', $sec_title, '', '', '', INPUT_REGULAR, '', 'section_title'),
-                'section_longtitle', '', array('class' => 'txp-form-field edit-section-longtitle')
-            );
-    }
-
-    $out[] = inputLabel(
-            'section_page',
-            selectInput('section_page', $all_pages, $sec_page, '', '', 'section_page'),
-            'uses_page', 'section_uses_page', array('class' => 'txp-form-field edit-section-uses-page')
+        $out[] =
+        inputLabel(
+            'section_name',
+            fInput('text', 'name', $sec_name, '', '', '', INPUT_REGULAR, '', 'section_name'),
+            'section_name',
+            '',
+            array('class' => 'txp-form-field edit-section-name')
         ).
         inputLabel(
-            'section_css',
-            selectInput('css', $all_styles, $sec_css, '', '', 'section_css'),
-            'uses_style', 'section_uses_css', array('class' => 'txp-form-field edit-section-uses-css')
+            'section_title',
+            fInput('text', 'title', $sec_title, '', '', '', INPUT_REGULAR, '', 'section_title'),
+            'section_longtitle',
+            '',
+            array('class' => 'txp-form-field edit-section-longtitle')
         );
+    }
+
+    $out[] =
+    inputLabel(
+        'section_page',
+        selectInput('section_page', $all_pages, $sec_page, '', '', 'section_page'),
+        'uses_page',
+        'section_uses_page',
+        array('class' => 'txp-form-field edit-section-uses-page')
+    ).
+    inputLabel(
+        'section_css',
+        selectInput('css', $all_styles, $sec_css, '', '', 'section_css'),
+        'uses_style',
+        'section_uses_css',
+        array('class' => 'txp-form-field edit-section-uses-css')
+    );
 
     if (!$is_default_section) {
         $out[] = inputLabel(
-                'on_front_page',
-                yesnoradio('on_frontpage', $sec_on_frontpage, '', $sec_name),
-                '', 'section_on_frontpage', array('class' => 'txp-form-field edit-section-on-frontpage')
-            ).
-            inputLabel(
-                'syndicate',
-                yesnoradio('in_rss', $sec_in_rss, '', $sec_name),
-                '', 'section_syndicate', array('class' => 'txp-form-field edit-section-syndicate')
-            ).
-            inputLabel(
-                'include_in_search',
-                yesnoradio('searchable', $sec_searchable, '', $sec_name),
-                '', 'section_searchable', array('class' => 'txp-form-field edit-section-searchable')
-            );
+            'on_front_page',
+            yesnoradio('on_frontpage', $sec_on_frontpage, '', $sec_name),
+            '',
+            'section_on_frontpage',
+            array('class' => 'txp-form-field edit-section-on-frontpage')
+        ).
+        inputLabel(
+            'syndicate',
+            yesnoradio('in_rss', $sec_in_rss, '', $sec_name),
+            '',
+            'section_syndicate',
+            array('class' => 'txp-form-field edit-section-syndicate')
+        ).
+        inputLabel(
+            'include_in_search',
+            yesnoradio('searchable', $sec_searchable, '', $sec_name),
+            '',
+            'section_searchable',
+            array('class' => 'txp-form-field edit-section-searchable')
+        );
     }
 
     $out[] = inputLabel(
-            'section_description',
-            '<textarea id="section_description" name="description" cols="'.INPUT_LARGE.'" rows="'.TEXTAREA_HEIGHT_SMALL.'">'.$sec_description.'</textarea>',
-            'description', 'section_description', array('class' => 'txp-form-field txp-form-field-textarea edit-section-description')
-        );
+        'section_description',
+        '<textarea id="section_description" name="description" cols="'.INPUT_LARGE.'" rows="'.TEXTAREA_HEIGHT_SMALL.'">'.$sec_description.'</textarea>',
+        'description',
+        'section_description',
+        array('class' => 'txp-form-field txp-form-field-textarea edit-section-description')
+    );
 
     $out[] = pluggable_ui('section_ui', 'extend_detail_form', '', $rs).
         graf(
@@ -848,13 +858,11 @@ function section_multi_edit()
     );
 
     if ($key && $sections) {
-        if (
-            safe_update(
-                'txp_section',
-                "$key = '".doSlash($val)."'",
-                "name IN (".join(',', quote_list($sections)).")"
-            )
-        ) {
+        if (safe_update(
+            'txp_section',
+            "$key = '".doSlash($val)."'",
+            "name IN (".join(',', quote_list($sections)).")"
+        )) {
             sec_section_list(gTxt('section_updated', array('{name}' => join(', ', $sections))));
 
             return;

--- a/textpattern/include/txp_tag.php
+++ b/textpattern/include/txp_tag.php
@@ -50,7 +50,8 @@ header('X-UA-Compatible: '.X_UA_COMPATIBLE);
                 'step'       => $step,
                 '_txp_token' => form_token(),
                 'textarray'  => (object)null,
-            )).';').
+            )).';'
+        ).
         script_js('textpattern.js', TEXTPATTERN_SCRIPT_URL).n;
     // Mandatory un-themable Textpattern core styles
     ?>
@@ -125,12 +126,13 @@ class BuilderTags
                 2
             );
 
-            $this->endform = graf(
-                    fInput('submit', '', gTxt('build'), 'publish')
-                ).
-                eInput('tag').
-                sInput('build').
-                hInput('tag_name', $this->tagname);
+            $this->endform =
+            graf(
+                fInput('submit', '', gTxt('build'), 'publish')
+            ).
+            eInput('tag').
+            sInput('build').
+            hInput('tag_name', $this->tagname);
 
             return $this->$method($this->tagname);
         }
@@ -703,7 +705,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'status'        => $this->tbStatusPop($status),
@@ -759,7 +762,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'id'            => $this->tbInput('id', $id),
@@ -768,16 +772,16 @@ class BuilderTags
                     'category'      => $this->tbCategoryPop($category),
                     'time'          => $this->tbTimePop($time),
                     'month'         => fInput(
-                            'text',
-                            'month',
-                            $month,
-                            '',
-                            '',
-                            '',
-                            7,
-                            '',
-                            'month'
-                        ).' ('.gTxt('yyyy-mm').')',
+                        'text',
+                        'month',
+                        $month,
+                        '',
+                        '',
+                        '',
+                        7,
+                        '',
+                        'month'
+                    ).' ('.gTxt('yyyy-mm').')',
                     'keywords'      => '<textarea name="keywords" id="keywords">'.$keywords.'</textarea>',
                     'has_excerpt'   => $this->tbYesNoPop('excerpted', $excerpted),
                     'expired'       => $this->tbYesNoPop('expired', $expired),
@@ -820,19 +824,20 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
-                $this->startblock.
-                $this->widgets(array(
-                    'use_thumbnail' => $this->tbYesNoPop('thumbnail', $thumbnail),
-                    'escape'        => $this->tbEscapePop($escape),
-                    'html_id'       => $this->tbInput('html_id', $html_id, INPUT_REGULAR),
-                    'class'         => $this->tbInput('class', $class, INPUT_REGULAR),
-                    'inline_style'  => $this->tbInput('style', $style, INPUT_REGULAR, 'inline_style'),
-                    'wraptag'       => $this->tbInput('wraptag', $wraptag),
-                )).
-                $this->endform
-            ).
-            $this->build($atts);
+        $out =
+        $this->tagbuildForm(
+            $this->startblock.
+            $this->widgets(array(
+                'use_thumbnail' => $this->tbYesNoPop('thumbnail', $thumbnail),
+                'escape'        => $this->tbEscapePop($escape),
+                'html_id'       => $this->tbInput('html_id', $html_id, INPUT_REGULAR),
+                'class'         => $this->tbInput('class', $class, INPUT_REGULAR),
+                'inline_style'  => $this->tbInput('style', $style, INPUT_REGULAR, 'inline_style'),
+                'wraptag'       => $this->tbInput('wraptag', $wraptag),
+            )).
+            $this->endform
+        ).
+        $this->build($atts);
 
         return $out;
     }
@@ -854,7 +859,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'escape'              => $this->tbEscapePop($escape),
@@ -898,7 +904,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'breadcrumb_separator' => $this->tbInput('separator', $separator, INPUT_XSMALL, 'breadcrumb_separator'),
@@ -935,7 +942,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'name'                  => $this->tbInput('name', $name, INPUT_REGULAR),
@@ -977,7 +985,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'type'                  => $this->tbTypePop($type),
@@ -1018,7 +1027,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'title'                 => $this->tbYesNoPop('title', $title),
@@ -1052,7 +1062,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'title'                 => $this->tbYesNoPop('title', $title),
@@ -1090,7 +1101,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'input_size' => $this->tbInput('size', $size, INPUT_TINY),
@@ -1124,7 +1136,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'msgcols' => $this->tbInput('cols', $cols, INPUT_TINY),
@@ -1149,7 +1162,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widget('comment_name_link', $this->tbYesNoPop('link', $link)).
                 $this->endform
@@ -1171,7 +1185,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'input_size' => $this->tbInput('size', $size, INPUT_TINY),
@@ -1233,7 +1248,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'time_format' => $this->tbInput('format', $format, INPUT_MEDIUM, 'time_format'),
@@ -1268,7 +1284,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'input_size' => $this->tbInput('size', $size, INPUT_TINY),
@@ -1298,7 +1315,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'form'    => $this->tbFormPop('form', 'comment', $form),
@@ -1330,7 +1348,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'id'      => $this->tbInput('id', $id),
@@ -1359,7 +1378,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'textonly'  => $this->tbYesNoPop('textonly', $textonly),
@@ -1389,7 +1409,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'id'      => $this->tbInput('id', $id),
@@ -1420,7 +1441,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'name'   => $this->tbCssPop($name),
@@ -1450,7 +1472,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'email_address' => $this->tbInput('email', $email, INPUT_REGULAR, 'email_address'),
@@ -1495,7 +1518,8 @@ class BuilderTags
 
         $label = $label ? $label : 'XML';
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'flavor'   => $this->tbFeedFlavorPop($flavor),
@@ -1528,7 +1552,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'id'   => $this->tbInput('id', $id),
@@ -1555,7 +1580,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'escape'  => $this->tbEscapePop($escape),
@@ -1581,7 +1607,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widget('time_format', $this->tbInput('format', $format, INPUT_MEDIUM, 'time_format')).
                 $this->endform
@@ -1605,7 +1632,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'escape'  => $this->tbEscapePop($escape),
@@ -1652,17 +1680,18 @@ class BuilderTags
             'html'        => 'HTML',
         );
 
-        $out = $this->tagbuildForm(
-            $this->startblock.
-            $this->widgets(array(
-                'type'        => ''.selectInput('type', $types, ($type ? $type : 'textpattern'), false, '', 'type'),
-                'id'          => $this->tbInput('id', $id),
-                'filename'    => $this->tbInput('filename', $filename, INPUT_REGULAR),
-                'link_text'   => $this->tbInput('linktext', ($linktext ? $linktext : ''), INPUT_REGULAR, 'link_text'),
-                'description' => '<textarea id="description" name="description" cols="'.INPUT_REGULAR.'" rows="'.TEXTAREA_HEIGHT_SMALL.'">'.$description.'</textarea>',
-            )).
-            $this->endform
-        );
+        $out =
+            $this->tagbuildForm(
+                $this->startblock.
+                $this->widgets(array(
+                    'type'        => ''.selectInput('type', $types, ($type ? $type : 'textpattern'), false, '', 'type'),
+                    'id'          => $this->tbInput('id', $id),
+                    'filename'    => $this->tbInput('filename', $filename, INPUT_REGULAR),
+                    'link_text'   => $this->tbInput('linktext', ($linktext ? $linktext : ''), INPUT_REGULAR, 'link_text'),
+                    'description' => '<textarea id="description" name="description" cols="'.INPUT_REGULAR.'" rows="'.TEXTAREA_HEIGHT_SMALL.'">'.$description.'</textarea>',
+                )).
+                $this->endform
+            );
 
         if ($step === 'build') {
             $desc = str_replace('&', '&#38;', txpspecialchars($description));
@@ -1724,7 +1753,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'category' => $this->tbCategoryPop($category, 'file'),
@@ -1755,7 +1785,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widget('time_format',
                     $this->tbInput('format', $format, INPUT_MEDIUM, 'time_format')).
@@ -1800,7 +1831,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'size_format' => ' '.selectInput('format', $formats, $format, true, '', 'size_format'),
@@ -1826,7 +1858,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'name' => $this->tbInput('name', $name, INPUT_REGULAR),
@@ -1851,7 +1884,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widget('name', $this->tbSectionPop('name', $this->tagname)).
                 $this->endform
@@ -1891,30 +1925,24 @@ class BuilderTags
             'html'        => 'HTML',
         );
 
-        $out = $this->tagbuildForm(
-            $this->startblock.
-            $this->widgets(array(
-                'type'         => ''.selectInput(
-                        'type',
-                        $types,
-                        ($type ? $type : 'textpattern'),
-                        false,
-                        '',
-                        'type'
-                    ),
-                'html_id'      => $this->tbInput('html_id', $html_id, INPUT_REGULAR),
-                'class'        => $this->tbInput('class', $class, INPUT_REGULAR),
-                'inline_style' => $this->tbInput('style', $style, INPUT_REGULAR, 'inline_style'),
-                'wraptag'      => $this->tbInput('wraptag', $wraptag),
-            )).
-            hInput('id', $id).
-            hInput('ext', $ext).
-            hInput('w', $w).
-            hInput('h', $h).
-            hInput('alt', $alt).
-            hInput('caption', $caption).
-            $this->endform
-        );
+        $out =
+            $this->tagbuildForm(
+                $this->startblock.
+                $this->widgets(array(
+                    'type'         => ''.selectInput('type', $types, ($type ? $type : 'textpattern'), false, '', 'type'),
+                    'html_id'      => $this->tbInput('html_id', $html_id, INPUT_REGULAR),
+                    'class'        => $this->tbInput('class', $class, INPUT_REGULAR),
+                    'inline_style' => $this->tbInput('style', $style, INPUT_REGULAR, 'inline_style'),
+                    'wraptag'      => $this->tbInput('wraptag', $wraptag),
+                )).
+                hInput('id', $id).
+                hInput('ext', $ext).
+                hInput('w', $w).
+                hInput('h', $h).
+                hInput('alt', $alt).
+                hInput('caption', $caption).
+                $this->endform
+            );
 
         if ($step === 'build') {
             $url = imagesrcurl($id, $ext);
@@ -1999,7 +2027,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'id'   => $this->tbInput('id', $id),
@@ -2029,7 +2058,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'title'    => $this->tbYesNoPop('title', $title),
@@ -2059,7 +2089,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'time_format' => $this->tbInput('format', $format, INPUT_MEDIUM, 'time_format'),
@@ -2089,7 +2120,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'escape'   => $this->tbEscapePop($escape),
@@ -2126,7 +2158,8 @@ class BuilderTags
 
         $label = (!$label) ? 'XML' : $label;
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'flavor'   => $this->tbFeedFlavorPop($flavor),
@@ -2157,7 +2190,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widget('escape', $this->tbEscapePop($escape)).
                 $this->endform
@@ -2181,7 +2215,8 @@ class BuilderTags
 
         $linktext = isset($_POST['linktext']) ? $_POST['linktext'] : null;
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'link_text' => $this->tbInput(
@@ -2213,7 +2248,8 @@ class BuilderTags
 
         $linktext = isset($_POST['linktext']) ? $_POST['linktext'] : null;
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'link_text'  => $this->tbInput(
@@ -2245,7 +2281,8 @@ class BuilderTags
 
         $linktext = isset($_POST['linktext']) ? $_POST['linktext'] : null;
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'link_text'  => $this->tbInput(
@@ -2275,7 +2312,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widget('rel', $this->tbInput('rel', $rel, INPUT_REGULAR)).
                 $this->endform
@@ -2317,7 +2355,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'category' => $this->tbCategoryPop($category, 'link'),
@@ -2344,7 +2383,8 @@ class BuilderTags
     {
         $linktext = isset($_POST['linktext']) ? $_POST['linktext'] : null;
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widget('link_text',
                     $this->tbInput(
@@ -2352,10 +2392,11 @@ class BuilderTags
                         ($linktext !== null ? $linktext : '<txp:text item="newer" />'),
                         INPUT_REGULAR,
                         'link_text'
-                    )).
+                    )
+                ).
                 $this->endform
             ).
-            $this->build(array(), $linktext);
+            $this->build(array(), $li $linktext);
 
         return $out;
     }
@@ -2377,7 +2418,8 @@ class BuilderTags
     {
         $linktext = isset($_POST['linktext']) ? $_POST['linktext'] : null;
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widget('link_text',
                     $this->tbInput(
@@ -2385,7 +2427,8 @@ class BuilderTags
                         ($linktext !== null ? $linktext : '<txp:text item="older" />'),
                         INPUT_REGULAR,
                         'link_text'
-                    )).
+                    )
+                ).
                 $this->endform
             ).
             $this->build(array(), $linktext);
@@ -2405,7 +2448,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widget('form', $this->tbFormPop('form', 'misc', $form)).
                 $this->endform
@@ -2427,10 +2471,13 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
-                $this->widget('title_separator',
-                    $this->tbInput('separator', $separator, INPUT_XSMALL, 'title_separator')).
+                $this->widget(
+                    'title_separator',
+                    $this->tbInput('separator', $separator, INPUT_XSMALL, 'title_separator')
+                ).
                 $this->endform
             ).
             $this->build($atts);
@@ -2451,7 +2498,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'login'    => $this->tbInput('login', $login, INPUT_REGULAR),
@@ -2481,7 +2529,8 @@ class BuilderTags
 
         $linktext = isset($_POST['linktext']) ? $_POST['linktext'] : null;
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'id'           => $this->tbInput('id', $id),
@@ -2524,7 +2573,8 @@ class BuilderTags
             's' => gTxt('Section'),
         );
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'type'         => ' '.selectInput('type', $types, $type, true, '', 'type'),
@@ -2555,7 +2605,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'time_format' => $this->tbInput('format', $format, INPUT_MEDIUM, 'time_format'),
@@ -2597,7 +2648,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'section'  => $this->tbSectionPop('section', $section),
@@ -2634,7 +2686,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'sort'     => $this->tbDiscussSortPop($sort),
@@ -2674,7 +2727,8 @@ class BuilderTags
 
         $label = (!$label) ? gTxt('tag_related_articles') : $label;
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'section'  => $this->tbSectionPop('section', $section),
@@ -2713,7 +2767,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'match_type'  => $this->tbPatternPop($match),
@@ -2746,7 +2801,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'time_format' => $this->tbInput('format', $format, INPUT_MEDIUM, 'time_format'),
@@ -2773,7 +2829,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'hilight'       => $this->tbInput('hilight', $hilight),
@@ -2821,7 +2878,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'name'                 => $this->tbSectionPop('name', $this->tagname),
@@ -2859,7 +2917,8 @@ class BuilderTags
 
         extract($atts);
 
-        $out = $this->tagbuildForm(
+        $out =
+            $this->tagbuildForm(
                 $this->startblock.
                 $this->widgets(array(
                     'include_default' => $this->tbYesNoPop('include_default', $include_default),

--- a/textpattern/index.php
+++ b/textpattern/index.php
@@ -35,7 +35,8 @@ if (@ini_get('register_globals')) {
         (array) $_POST,
         (array) $_COOKIE,
         (array) $_FILES,
-        (array) $_SERVER);
+        (array) $_SERVER
+    );
 
     // As the deliberately awkward-named local variable $_txpfoo MUST NOT be unset to avoid notices further
     // down, we must remove any potentially identical-named global from the list of global names here.
@@ -219,11 +220,13 @@ if ($connected && numRows(safe_query("SHOW TABLES LIKE '".PFX."textpattern'"))) 
         echo $trace->summary();
         echo $trace->result();
     } else {
-        foreach($trace->summary(true) as $key => $value) {
-           header('X-Textpattern-'.preg_replace('/[^\w]+/', '', $key).': '.$value);
+        foreach ($trace->summary(true) as $key => $value) {
+            header('X-Textpattern-'.preg_replace('/[^\w]+/', '', $key).': '.$value);
         }
     }
 } else {
-    txp_die('Database connection was successful, but the <code>textpattern</code> table was not found.',
-        '503 Service Unavailable');
+    txp_die(
+        'Database connection was successful, but the <code>textpattern</code> table was not found.',
+        '503 Service Unavailable'
+    );
 }

--- a/textpattern/publish.php
+++ b/textpattern/publish.php
@@ -185,10 +185,10 @@ if (!empty($feed) && in_array($feed, array('atom', 'rss'), true)) {
     include txpath."/publish/{$feed}.php";
     echo $feed();
     if ($production_status !== 'live') {
-      echo $trace->summary();
-      if ($production_status === 'debug') {
-        echo $trace->result();
-      }
+        echo $trace->summary();
+        if ($production_status === 'debug') {
+            echo $trace->result();
+        }
     }
     exit;
 }
@@ -282,7 +282,8 @@ function preText($s, $prefs)
                 // only way to make it multibyte-safe without breaking
                 // backwards-compatibility.
                 case urldecode(strtolower(urlencode(gTxt('section')))):
-                    $out['s'] = (ckEx('section', $u2)) ? $u2 : ''; $is_404 = empty($out['s']);
+                    $out['s'] = (ckEx('section', $u2)) ? $u2 : '';
+                    $is_404 = empty($out['s']);
                     break;
 
                 case urldecode(strtolower(urlencode(gTxt('category')))):
@@ -319,7 +320,6 @@ function preText($s, $prefs)
                 default:
                     // Then see if the prefs-defined permlink scheme is usable.
                     switch ($permlink_mode) {
-
                         case 'section_id_title':
                             if (empty($u2)) {
                                 $out['s'] = (ckEx('section', $u1)) ? $u1 : '';
@@ -330,7 +330,6 @@ function preText($s, $prefs)
                                 $out['id'] = @$rs['ID'];
                                 $is_404 = (empty($out['s']) or empty($out['id']));
                             }
-
                             break;
 
                         case 'year_month_day_title':
@@ -357,7 +356,6 @@ function preText($s, $prefs)
                                 $out['s'] = (!empty($rs['Section'])) ? $rs['Section'] : '';
                                 $is_404 = (empty($out['s']) or empty($out['id']));
                             }
-
                             break;
 
                         case 'section_title':
@@ -370,7 +368,6 @@ function preText($s, $prefs)
                                 $out['s'] = isset($rs['Section']) ? $rs['Section'] : '';
                                 $is_404 = (empty($out['s']) or empty($out['id']));
                             }
-
                             break;
 
                         case 'title_only':
@@ -379,7 +376,6 @@ function preText($s, $prefs)
                             $out['s'] = (empty($rs['Section']) ? ckEx('section', $u1) :
                                     $rs['Section']);
                             $is_404 = empty($out['s']);
-
                             break;
 
                         case 'id_title':
@@ -393,7 +389,6 @@ function preText($s, $prefs)
                                 $out['s'] = ckEx('section', $u1) ? $u1 : '';
                                 $is_404 = empty($out['s']);
                             }
-
                             break;
                     }
 
@@ -476,7 +471,11 @@ function preText($s, $prefs)
             }
 
             $fn = empty($out['filename']) ? '' : " AND filename = '".doSlash($out['filename'])."'";
-            $rs = safe_row('*', 'txp_file', "id = ".intval($out['id'])." AND status = ".STATUS_LIVE." AND created <= ".now('created').$fn);
+            $rs = safe_row(
+                '*',
+                'txp_file',
+                "id = ".intval($out['id'])." AND status = ".STATUS_LIVE." AND created <= ".now('created').$fn
+            );
         }
 
         return (!empty($rs)) ? array_merge($out, $rs) : array('s' => 'file_download', 'file_error' => 404);
@@ -502,9 +501,11 @@ function preText($s, $prefs)
     }
 
     if (is_numeric($id) and !$is_404) {
-        $a = safe_row("*, UNIX_TIMESTAMP(Posted) AS uPosted, UNIX_TIMESTAMP(Expires) AS uExpires, UNIX_TIMESTAMP(LastMod) AS uLastMod",
+        $a = safe_row(
+            "*, UNIX_TIMESTAMP(Posted) AS uPosted, UNIX_TIMESTAMP(Expires) AS uExpires, UNIX_TIMESTAMP(LastMod) AS uLastMod",
             'textpattern',
-            "ID = ".intval($id).(gps('txpreview') ? '' : " AND Status IN (".STATUS_LIVE.",".STATUS_STICKY.")"));
+            "ID = ".intval($id).(gps('txpreview') ? '' : " AND Status IN (".STATUS_LIVE.",".STATUS_STICKY.")")
+        );
 
         if ($a) {
             $out['id_keywords'] = $a['Keywords'];
@@ -660,15 +661,15 @@ function output_file_download($filename)
     // Deal with error.
     if (isset($file_error)) {
         switch ($file_error) {
-        case 403:
-            txp_die(gTxt('403_forbidden'), '403');
-            break;
-        case 404:
-            txp_die(gTxt('404_not_found'), '404');
-            break;
-        default:
-            txp_die(gTxt('500_internal_server_error'), '500');
-            break;
+            case 403:
+                txp_die(gTxt('403_forbidden'), '403');
+                break;
+            case 404:
+                txp_die(gTxt('404_not_found'), '404');
+                break;
+            default:
+                txp_die(gTxt('500_internal_server_error'), '500');
+                break;
         }
     }
 }
@@ -704,7 +705,6 @@ function doArticles($atts, $iscustom, $thing = null)
     $customlAtts = array_null(array_flip($customFields));
 
     if ($iscustom) {
-
         // Custom articles must not render search results.
         $q = '';
 
@@ -963,9 +963,11 @@ function doArticles($atts, $iscustom, $thing = null)
         $safe_sort = doSlash($sort);
     }
 
-    $rs = safe_rows_start("*, UNIX_TIMESTAMP(Posted) AS uPosted, UNIX_TIMESTAMP(Expires) AS uExpires, UNIX_TIMESTAMP(LastMod) AS uLastMod".$score,
+    $rs = safe_rows_start(
+        "*, UNIX_TIMESTAMP(Posted) AS uPosted, UNIX_TIMESTAMP(Expires) AS uExpires, UNIX_TIMESTAMP(LastMod) AS uLastMod".$score,
         'textpattern',
-        "$where ORDER BY $safe_sort LIMIT ".intval($pgoffset).", ".intval($limit));
+        "$where ORDER BY $safe_sort LIMIT ".intval($pgoffset).", ".intval($limit)
+    );
 
     // Get the form name.
     if ($q && !$issticky) {
@@ -1058,9 +1060,11 @@ function doArticle($atts, $thing = null)
 
         $q_status = ($status ? "AND Status = ".intval($status) : "AND Status IN (".STATUS_LIVE.",".STATUS_STICKY.")");
 
-        $rs = safe_row("*, UNIX_TIMESTAMP(Posted) AS uPosted, UNIX_TIMESTAMP(Expires) AS uExpires, UNIX_TIMESTAMP(LastMod) AS uLastMod",
+        $rs = safe_row(
+            "*, UNIX_TIMESTAMP(Posted) AS uPosted, UNIX_TIMESTAMP(Expires) AS uExpires, UNIX_TIMESTAMP(LastMod) AS uLastMod",
             'textpattern',
-            "ID = $id $q_status LIMIT 1");
+            "ID = $id $q_status LIMIT 1"
+        );
 
         if ($rs) {
             extract($rs);


### PR DESCRIPTION
Related to [this](https://github.com/textpattern/textpattern/issues/412).

It's a first step and It can still be impoved; I didn't change constant, class and method name letter cases for example, and some changes can be discussed but I think that it is a bit better now.

Some things I'm thinking and that could be discussed 
- a lot of `td()` are now inline but you could want to separate these lines (see [here](https://github.com/NicolasGraph/textpattern/blob/master/textpattern/include/txp_file.php#L436));
- In most cases I kept `column_head()` arguments on two lines because the last on is the only one on the second line and others are shorts, so I thought you could want to keep it as is (see [here](https://github.com/NicolasGraph/textpattern/blob/master/textpattern/include/txp_file.php#L319);
- each last and short form() arguments are on one line, maybe I should keep them together (see [here](https://github.com/NicolasGraph/textpattern/blob/master/textpattern/include/txp_file.php#L228).