### PR TITLE
Removing deprecated warning trace_add()

### DIFF
--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -5644,8 +5644,6 @@ function trace_add($msg, $level = 0, $dummy = null)
     } else {
         $trace->log($msg);
     }
-
-    trigger_error(gTxt('deprecated_function_with', array('{name}' => __FUNCTION__, '{with}' => 'class Trace')), E_USER_NOTICE);
 }
 
 /**


### PR DESCRIPTION
Related topic: http://forum.textpattern.com/viewtopic.php?id=46841