### PR TITLE
Show option "Change author" only if the user has rights

### DIFF
--- a/textpattern/include/txp_list.php
+++ b/textpattern/include/txp_list.php
@@ -563,7 +563,7 @@ function list_multiedit_form($page, $sort, $dir, $crit, $search_method)
         unset($methods['changecategory1'], $methods['changecategory2']);
     }
 
-    if (has_single_author('textpattern', 'AuthorID')) {
+    if (has_single_author('textpattern', 'AuthorID') || !has_privs('article.edit')) {
         unset($methods['changeauthor']);
     }
 


### PR DESCRIPTION
Issue: #774 

A similar situation may occur with: `image`, `link`, `file`. Now there are not checked right to change the author.
Probably it is necessary add a check of the rights: `image.edit`, `link.edit`, `file.edit` ?
