### PR TITLE
Swap apache_request_headers() for $_SERVER

### DIFF
--- a/textpattern/publish/atom.php
+++ b/textpattern/publish/atom.php
@@ -298,14 +298,8 @@ function atom()
         $hims = serverset('HTTP_IF_MODIFIED_SINCE');
         $imsd = ($hims) ? strtotime($hims) : 0;
 
-        if (is_callable('apache_request_headers')) {
-            $headers = apache_request_headers();
-
-            if (isset($headers["A-IM"])) {
-                $canaim = strpos($headers["A-IM"], "feed");
-            } else {
-                $canaim = false;
-            }
+        if (isset($_SERVER["HTTP_A_IM"])) {
+            $canaim = strpos($_SERVER["HTTP_A_IM"], "feed");
         } else {
             $canaim = false;
         }

--- a/textpattern/publish/rss.php
+++ b/textpattern/publish/rss.php
@@ -223,14 +223,8 @@ function rss()
         $hims = serverset('HTTP_IF_MODIFIED_SINCE');
         $imsd = ($hims) ? strtotime($hims) : 0;
 
-        if (is_callable('apache_request_headers')) {
-            $headers = apache_request_headers();
-
-            if (isset($headers["A-IM"])) {
-                $canaim = strpos($headers["A-IM"], "feed");
-            } else {
-                $canaim = false;
-            }
+        if (isset($_SERVER["HTTP_A_IM"])) {
+            $canaim = strpos($_SERVER["HTTP_A_IM"], "feed");
         } else {
             $canaim = false;
         }

--- a/textpattern/vendors/Textpattern/Http/Request.php
+++ b/textpattern/vendors/Textpattern/Http/Request.php
@@ -520,12 +520,6 @@ class Request
             return $this->headers;
         }
 
-        if (function_exists('apache_request_headers')) {
-            if ($this->headers = apache_request_headers()) {
-                return $this->headers;
-            }
-        }
-
         $this->headers = array();
 
         foreach ($_SERVER as $name => $value) {


### PR DESCRIPTION
Apache isn’t the only server in town anymore, and there is no reason to use this method rather than the superglobal variable.
