### PR TITLE
Uncomment and enable HTTP 226 responses

### DIFF
--- a/textpattern/publish/atom.php
+++ b/textpattern/publish/atom.php
@@ -350,8 +350,7 @@ function atom()
         }
 
         if ($cutarticles) {
-            // header("HTTP/1.1 226 IM Used");
-            // This should be used as opposed to 200, but Apache doesn't like it.
+            header("HTTP/1.1 226 IM Used");
             header("Cache-Control: no-store, im");
             header("IM: feed");
         }

--- a/textpattern/publish/rss.php
+++ b/textpattern/publish/rss.php
@@ -271,8 +271,7 @@ function rss()
         }
 
         if ($cutarticles) {
-            // header("HTTP/1.1 226 IM Used");
-            // This should be used as opposed to 200, but Apache doesn't like it.
+            header("HTTP/1.1 226 IM Used");
             header("Cache-Control: no-store, im");
             header("IM: feed");
         }


### PR DESCRIPTION
This was a problem with Apache 1.3 (since patched), but Apache 2+ and other web servers don't have a problem with this anymore.