### PR TITLE
Tell robots to not index error pages

### DIFF
--- a/textpattern/lib/txplib_db.php
+++ b/textpattern/lib/txplib_db.php
@@ -1454,6 +1454,7 @@ function db_down()
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="robots" content="noindex">
     <title>Database unavailable</title>
 </head>
 <body>

--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -5041,6 +5041,7 @@ function txp_die($msg, $status = '503', $url = '')
 <html lang="en">
 <head>
    <meta charset="utf-8">
+   <meta name="robots" content="noindex">
    <title>Textpattern Error: <txp:error_status /></title>
 </head>
 <body>


### PR DESCRIPTION
Provide a hint to search engines that errors shouldn’t be index. Will clear once the error is resolved.