### PR TITLE
Use rel="nofollow" in “Published with” footer message

### DIFF
--- a/textpattern/setup/pages/archive.txp
+++ b/textpattern/setup/pages/archive.txp
@@ -178,7 +178,7 @@
         <p>
             <small>
                 <txp:text item="published_with" />
-                <a rel="external" href="http://textpattern.com" title="<txp:text item="go_txp_com" />">Textpattern CMS</a>
+                <a rel="external nofollow" href="http://textpattern.com" title="<txp:text item="go_txp_com" />">Textpattern CMS</a>
             </small>
         </p>
     </footer>

--- a/textpattern/setup/pages/default.txp
+++ b/textpattern/setup/pages/default.txp
@@ -208,7 +208,7 @@
         <p>
             <small>
                 <txp:text item="published_with" />
-                <a rel="external" href="http://textpattern.com" title="<txp:text item="go_txp_com" />">Textpattern CMS</a>
+                <a rel="external nofollow" href="http://textpattern.com" title="<txp:text item="go_txp_com" />">Textpattern CMS</a>
             </small>
         </p>
     </footer>

--- a/textpattern/setup/pages/error_default.txp
+++ b/textpattern/setup/pages/error_default.txp
@@ -102,7 +102,7 @@
         <p>
             <small>
                 <txp:text item="published_with" />
-                <a rel="external" href="http://textpattern.com" title="<txp:text item="go_txp_com" />">Textpattern CMS</a>
+                <a rel="external nofollow" href="http://textpattern.com" title="<txp:text item="go_txp_com" />">Textpattern CMS</a>
             </small>
         </p>
     </footer>


### PR DESCRIPTION
Textpattern is currently violating [Google’s link building scheme](https://support.google.com/webmasters/answer/66356?hl=en) rule:
* Widely distributed links in the footers or templates of various sites

Apply nofollow to link to avoid penalty.