### PR TITLE
Include feed type="" attr in feed_link

### DIFF
--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -522,15 +522,15 @@ function feed_link($atts, $thing = null)
 
     $title = txpspecialchars($title);
 
-    if ($format == 'link') {
-        $type = ($flavor == 'atom') ? 'application/atom+xml' : 'application/rss+xml';
+    $type = ($flavor == 'atom') ? 'application/atom+xml' : 'application/rss+xml';
 
+    if ($format == 'link') {
         return '<link rel="alternate" type="'.$type.'" title="'.$title.'" href="'.$url.'" />';
     }
 
     $txt = ($thing === null ? $label : parse($thing));
 
-    $out = href($txt, $url, ' title="'.$title.'"');
+    $out = href($txt, $url, array('type' => $type, 'title' => $title));
 
     return ($wraptag) ? doTag($out, $wraptag, $class) : $out;
 }
@@ -563,13 +563,13 @@ function link_feed_link($atts)
 
     $title = txpspecialchars($title);
 
-    if ($format == 'link') {
-        $type = ($flavor == 'atom') ? 'application/atom+xml' : 'application/rss+xml';
+    $type = ($flavor == 'atom') ? 'application/atom+xml' : 'application/rss+xml';
 
+    if ($format == 'link') {
         return '<link rel="alternate" type="'.$type.'" title="'.$title.'" href="'.$url.'" />';
     }
 
-    $out = href($label, $url, ' title="'.$title.'"');
+    $out = href($label, $url, array('type' => $type, 'title' => $title));
 
     return ($wraptag) ? doTag($out, $wraptag, $class) : $out;
 }


### PR DESCRIPTION
Helps designers target feed links more easily with CSS, and help robots and software figure out what the link leads to without following it.

All other major CMS provide this at least in their default themes.