### PR TITLE
Redirects should have a linked body message

### DIFF
--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -5026,7 +5026,7 @@ function txp_die($msg, $status = '503', $url = '')
     if ($url && in_array($code, array(301, 302, 303, 307))) {
         ob_end_clean();
         header("Location: $url", true, $code);
-        die('<html><head><meta http-equiv="refresh" content="0;URL='.txpspecialchars($url).'"></head><body></body></html>');
+        die('<html><head><meta http-equiv="refresh" content="0;URL='.txpspecialchars($url).'"></head><body><p>Document has <a href="'.txpspecialchars($url).'">moved here</a>.</p></body></html>');
     }
 
     if ($connected && @txpinterface == 'public') {


### PR DESCRIPTION
This is dead code, as far as I can tell; but fixing it anyway. Not all clients follow redirects automatically.

Redirect pages generated by all major web servers include a body message for redirects.

Users see informational page instead of blank page when redirect fails because of caching, network issues, tweaked browsers, accessibility settings, misuse of curl, etc. etc.