### PR TITLE
WordPress-style URL alias ?feed=1 and /feed for Atom feeds

### DIFF
--- a/textpattern/publish.php
+++ b/textpattern/publish.php
@@ -231,12 +231,12 @@ function preText($s, $prefs)
     // Set messy variables.
     $out = makeOut('id', 's', 'c', 'context', 'q', 'm', 'pg', 'p', 'month', 'author');
 
-    if (gps('rss')) {
-        $out['feed'] = 'rss';
+    if (gps('atom') || gps('feed')) {
+        $out['feed'] = 'atom';
     }
 
-    if (gps('atom')) {
-        $out['feed'] = 'atom';
+    if (gps('rss')) {
+        $out['feed'] = 'rss';
     }
 
     // Some useful vars for taghandlers, plugins.
@@ -274,6 +274,10 @@ function preText($s, $prefs)
         if (strlen($u1)) {
             switch ($u1) {
                 case 'atom':
+                    $out['feed'] = 'atom';
+                    break;
+
+                case 'feed':
                     $out['feed'] = 'atom';
                     break;
 


### PR DESCRIPTION
Allows for guessable URLs for feeds. No redirect as that would waste bandwidth and slow down performance. Content duplication already handled by the  `atom:self` element for Atom and RSS.

`/feed` is a common endpoint for syndication feeds used by *a lot* of content management systems and websites.
