### PR TITLE
ETag must be an exact match

### DIFF
--- a/textpattern/publish/atom.php
+++ b/textpattern/publish/atom.php
@@ -340,7 +340,7 @@ function atom()
 
         $etag = @join("-", $etags);
 
-        if (strstr($hinm, $etag)) {
+        if ($hinm == $etag)) {
             txp_status_header('304 Not Modified');
             exit(0);
         }

--- a/textpattern/publish/rss.php
+++ b/textpattern/publish/rss.php
@@ -265,7 +265,7 @@ function rss()
 
         $etag = @join("-", $etags);
 
-        if (strstr($hinm, $etag)) {
+        if ($hinm == $etag)) {
             txp_status_header('304 Not Modified');
             exit(0);
         }


### PR DESCRIPTION
Fixes these issues:
- Partial string match will incorrectly report "304" when the `rss_how_many` setting is increased. (Or a `?limit=value` is masked and increased through mod_rewrite.)
- Apache appends a `"-<encoding>"` suffix to etags (e.g. `ETag: "etagvalue-gzip"`) when it’s been processed through an encoding output filter for which Textpattern shouldn’t reply 304. Breaks caching when two non-equivalent resources (different encodings) report to have the same ETag.

You can see the headers not updating in response to content negotiation here: https://redbot.org/?uri=http%3A%2F%2Ftextpattern.com%2Fatom%2F%3Fsection%3Dweblog (or see a [snapshot from archive.org](https://web.archive.org/web/20161026105953/https://redbot.org/?uri=http%3A%2F%2Ftextpattern.com%2Fatom%2F%3Fsection%3Dweblog) if you’re from the future.)
