### PR TITLE
Fix feed delta implementation.

### DIFF
--- a/textpattern/publish/atom.php
+++ b/textpattern/publish/atom.php
@@ -239,7 +239,6 @@ function atom()
 
                 $articles[$ID] = tag(n.t.t.join(n.t.t, $e).n.$cb, 'entry');
 
-                $etags[$ID] = strtoupper(dechex(crc32($articles[$ID])));
                 $dates[$ID] = $uLastMod;
             }
         }
@@ -267,7 +266,6 @@ function atom()
 
                 $articles[$id] = tag(n.t.t.join(n.t.t, $e).n, 'entry');
 
-                $etags[$id] = strtoupper(dechex(crc32($articles[$id])));
                 $dates[$id] = $date;
             }
         }
@@ -294,59 +292,39 @@ function atom()
             }
         }
     } else {
-        handle_lastmod();
-        $hims = serverset('HTTP_IF_MODIFIED_SINCE');
-        $imsd = ($hims) ? strtotime($hims) : 0;
+        header('Vary: A-IM, If-None-Match, If-Modified-Since');
 
-        if (isset($_SERVER["HTTP_A_IM"])) {
-            $canaim = strpos($_SERVER["HTTP_A_IM"], "feed");
-        } else {
-            $canaim = false;
+        handle_lastmod(max($dates));
+
+        if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE'])) {
+            $hims = $_SERVER['HTTP_IF_MODIFIED_SINCE'];
+            $imsd = ($hims) ? strtotime($hims) : 0;
+        } elseif (isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
+            $hinm = trim(trim($_SERVER['HTTP_IF_NONE_MATCH']), '"');
+            $inmd = ($hinm) ? base_convert(explode('-gzip', $hinm)[0], 32, 10) : 0;
         }
-
-        $hinm = stripslashes(serverset('HTTP_IF_NONE_MATCH'));
+        if (isset($imsd) || isset($inmd)) {
+          $clfd = max(intval($imsd), intval($inmd));
+        }
 
         $cutarticles = false;
 
-        if ($canaim !== false) {
-            foreach ($articles as $id => $thing) {
-                if (strpos($hinm, $etags[$id])) {
-                    unset($articles[$id]);
-                    $cutarticles = true;
-                    $cut_etag = true;
-                }
+        if (isset($_SERVER["HTTP_A_IM"]) &&
+            strpos($_SERVER["HTTP_A_IM"], "feed") &&
+            isset($clfd) && $clfd > 0) {
 
-                if ($dates[$id] < $imsd) {
+            foreach($articles as $id => $entry) {
+                if ($dates[$id] <= $clfd) {
                     unset($articles[$id]);
                     $cutarticles = true;
-                    $cut_time = true;
                 }
             }
         }
 
-        if (isset($cut_etag) && isset($cut_time)) {
-            header("Vary: If-None-Match, If-Modified-Since");
-        } elseif (isset($cut_etag)) {
-            header("Vary: If-None-Match");
-        } elseif (isset($cut_time)) {
-            header("Vary: If-Modified-Since");
-        }
-
-        $etag = @join("-", $etags);
-
-        if (strstr($hinm, $etag)) {
-            txp_status_header('304 Not Modified');
-            exit(0);
-        }
-
-        if ($etag) {
-            header('ETag: "'.$etag.'"');
-        }
-
         if ($cutarticles) {
             header("HTTP/1.1 226 IM Used");
-            header("Cache-Control: no-store, im");
-            header("IM: feed");
+            header("Cache-Control: IM", false);
+            header("IM: feed", false);
         }
     }
 
@@ -354,6 +332,9 @@ function atom()
 
     header('Content-Type: application/atom+xml; charset=utf-8');
 
-    return chr(60).'?xml version="1.0" encoding="UTF-8"?'.chr(62).n.
-        '<feed xml:lang="'.txpspecialchars($language).'" xmlns="http://www.w3.org/2005/Atom">'.join(n, $out).'</feed>';
+    return
+        '<?xml version="1.0" encoding="UTF-8"?>'.n.
+        '<feed xml:lang="'.txpspecialchars($language).'" xmlns="http://www.w3.org/2005/Atom">'.n.
+        join(n, $out).n.
+        '</feed>';
 }

--- a/textpattern/publish/rss.php
+++ b/textpattern/publish/rss.php
@@ -171,8 +171,7 @@ function rss()
 
                 $articles[$ID] = tag($item, 'item');
 
-                $etags[$ID] = strtoupper(dechex(crc32($articles[$ID])));
-                $dates[$ID] = $uPosted;
+                $dates[$ID] = $uLastMod;
             }
         }
     } elseif ($area == 'link') {
@@ -192,8 +191,7 @@ function rss()
                     tag(safe_strftime('rfc822', $uDate), 'pubDate');
                 $articles[$id] = tag($item, 'item');
 
-                $etags[$id] = strtoupper(dechex(crc32($articles[$id])));
-                $dates[$id] = $date;
+                $dates[$id] = $uLastMod;
             }
         }
     }
@@ -219,65 +217,45 @@ function rss()
             }
         }
     } else {
-        handle_lastmod();
-        $hims = serverset('HTTP_IF_MODIFIED_SINCE');
-        $imsd = ($hims) ? strtotime($hims) : 0;
+        header('Vary: A-IM, If-None-Match, If-Modified-Since');
 
-        if (isset($_SERVER["HTTP_A_IM"])) {
-            $canaim = strpos($_SERVER["HTTP_A_IM"], "feed");
-        } else {
-            $canaim = false;
+        handle_lastmod(max($dates));
+
+        if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE'])) {
+            $hims = $_SERVER['HTTP_IF_MODIFIED_SINCE'];
+            $imsd = ($hims) ? strtotime($hims) : 0;
+        } elseif (isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
+            $hinm = trim(trim($_SERVER['HTTP_IF_NONE_MATCH']), '"');
+            $inmd = ($hinm) ? base_convert(explode('-gzip', $hinm)[0], 32, 10) : 0;
         }
-
-        $hinm = stripslashes(serverset('HTTP_IF_NONE_MATCH'));
+        if (isset($imsd) || isset($inmd)) {
+          $clfd = max(intval($imsd), intval($inmd));
+        }
 
         $cutarticles = false;
 
-        if ($canaim !== false) {
-            foreach ($articles as $id => $thing) {
-                if (strpos($hinm, $etags[$id]) !== false) {
-                    unset($articles[$id]);
-                    $cutarticles = true;
-                    $cut_etag = true;
-                }
+        if (isset($_SERVER["HTTP_A_IM"]) &&
+            strpos($_SERVER["HTTP_A_IM"], "feed") &&
+            isset($clfd) && $clfd > 0) {
 
-                if ($dates[$id] < $imsd) {
+            foreach($articles as $id => $entry) {
+                if ($dates[$id] <= $clfd) {
                     unset($articles[$id]);
                     $cutarticles = true;
-                    $cut_time = true;
                 }
             }
         }
 
-        if (isset($cut_etag) && isset($cut_time)) {
-            header("Vary: If-None-Match, If-Modified-Since");
-        } elseif (isset($cut_etag)) {
-            header("Vary: If-None-Match");
-        } elseif (isset($cut_time)) {
-            header("Vary: If-Modified-Since");
-        }
-
-        $etag = @join("-", $etags);
-
-        if (strstr($hinm, $etag)) {
-            txp_status_header('304 Not Modified');
-            exit(0);
-        }
-
         if ($cutarticles) {
             header("HTTP/1.1 226 IM Used");
-            header("Cache-Control: no-store, im");
-            header("IM: feed");
+            header("Cache-Control: IM", false);
+            header("IM: feed", false);
         }
     }
 
     $out = array_merge($out, $articles);
 
     header("Content-Type: application/rss+xml; charset=utf-8");
-
-    if (isset($etag)) {
-        header('ETag: "'.$etag.'"');
-    }
 
     return
         '<?xml version="1.0" encoding="utf-8"?>'.n.


### PR DESCRIPTION
New implementation supports returning feed deltas (just the new entries)
if the A-IM plus either the If-Modified-Since or If-None-Match headers.

* Always send a Vary header for feeds so caches will be variant aware.
* Disable caching when Txp is not in production.
* Don't lie about last modification dates.
* Derive ETags from last modification timestamps.

Follow up from issue #811, obsoletes #826.