### PR TITLE
file panel – date sort in file list

### DIFF
--- a/textpattern/include/txp_file.php
+++ b/textpattern/include/txp_file.php
@@ -98,7 +98,7 @@ function file_list($message = '')
     if ($sort === '') {
         $sort = get_pref('file_sort_column', 'filename');
     } else {
-        if (!in_array($sort, array('id', 'description', 'category', 'title', 'downloads', 'author'))) {
+        if (!in_array($sort, array('id', 'description', 'category', 'title', 'date', 'downloads', 'author'))) {
             $sort = 'filename';
         }
 
@@ -125,6 +125,9 @@ function file_list($message = '')
         case 'title':
             $sort_sql = "txp_file.title $dir, txp_file.filename DESC";
             break;
+        case 'date':
+            $sort_sql = "txp_file.created $dir, txp_file.filename DESC";
+            break;        
         case 'downloads':
             $sort_sql = "txp_file.downloads $dir, txp_file.filename DESC";
             break;
@@ -327,7 +330,7 @@ function file_list($message = '')
                         (('title' == $sort) ? "$dir " : '').'txp-list-col-title'
                 ).
                 column_head(
-                    'date', 'date', 'image', true, $switch_dir, $crit, $search_method,
+                    'date', 'date', 'file', true, $switch_dir, $crit, $search_method,
                         (('date' == $sort) ? "$dir " : '').'txp-list-col-created date'
                 ).
                 column_head(


### PR DESCRIPTION
Two mini patches
– clicking on date column head in the file panel currently switches to the image panel!?
– add support for sorting the file list by date (using created date)