### PR TITLE
Reworked imageFetchInfo() …

### DIFF
--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -3642,10 +3642,11 @@ function image_url($atts, $thing = null)
 
 function image_author($atts)
 {
-    global $thisimage, $s;
-    assert_image();
+    global $s;
 
     extract(lAtts(array(
+        'name'         => '',
+        'id'           => '',
         'class'        => '',
         'link'         => 0,
         'title'        => 1,
@@ -3654,9 +3655,9 @@ function image_author($atts)
         'wraptag'      => '',
     ), $atts));
 
-    if ($thisimage['author']) {
-        $author_name = get_author_name($thisimage['author']);
-        $display_name = txpspecialchars(($title) ? $author_name : $thisimage['author']);
+    if ($imageData = imageFetchInfo($id, $name)) {
+        $author_name = get_author_name($imageData['author']);
+        $display_name = txpspecialchars(($title) ? $author_name : $imageData['author']);
 
         $section = ($this_section) ? ($s == 'default' ? '' : $s) : $section;
 

--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -3250,7 +3250,7 @@ function image_index($atts)
     
     global $c;
 
-    extract(lAtts(array(
+    lAtts(array(
         'label'    => '',
         'break'    => br,
         'wraptag'  => '',
@@ -3260,7 +3260,7 @@ function image_index($atts)
         'limit'    => 0,
         'offset'   => 0,
         'sort'     => 'name ASC',
-    ), $atts));
+    ), $atts);
 
     if (!isset($atts['category'])) {
         $atts['category'] = $c;
@@ -3544,15 +3544,24 @@ function image_url($atts, $thing = null)
         'thumbnail' => 0,
         'link'      => 'auto',
     ), $atts));
-
-    if ($imageData = imageFetchInfo($id, $name)) {
-        $url = imagesrcurl($imageData['id'], $imageData['ext'], $thumbnail);
-        $link = ($link == 'auto') ? (($thing) ? 1 : 0) : $link;
-        $out = ($thing) ? parse($thing) : $url;
-        return ($link) ? href($out, $url) : $out;
+    
+    if (($name || $id) && $thing) {
+        global $thisimage;
+        $stash = $thisimage;
     }
 
-    return '';
+    if ($thisimage = imageFetchInfo($id, $name)) {
+        $url = imagesrcurl($thisimage['id'], $thisimage['ext'], $thumbnail);
+        $link = ($link == 'auto') ? (($thing) ? 1 : 0) : $link;
+        $out = ($thing) ? parse($thing) : $url;
+        $out = ($link) ? href($out, $url) : $out;
+    }
+
+    if (isset($stash)) {
+        $thisimage = $stash;
+    }
+    
+    return isset($out) ? $out : '';
 }
 
 // -------------------------------------------------------------

--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -3242,6 +3242,8 @@ function search_result_count($atts)
 
 function image_index($atts)
 {
+    trigger_error(gTxt('deprecated_tag'), E_USER_NOTICE);
+    
     global $s, $c;
 
     extract(lAtts(array(
@@ -3256,42 +3258,18 @@ function image_index($atts)
         'sort'     => 'name ASC',
     ), $atts));
 
-    if (isset($atts['category'])) {
-        // Override the global.
-        $c = $category;
+    if (!isset($atts['category'])) {
+        $atts['category'] = $c;
     }
 
-    $qparts = array(
-        "category = '".doSlash($c)."' AND thumbnail = 1",
-        "ORDER BY ".doSlash($sort),
-        ($limit) ? "LIMIT ".intval($offset).", ".intval($limit) : '',
-    );
-
-    $rs = safe_rows_start("*", 'txp_image',  join(' ', $qparts));
-
-    if ($rs) {
-        $out = array();
-
-        while ($a = nextRow($rs)) {
-            extract($a);
-            $dims = ($thumb_h ? " height=\"$thumb_h\"" : '').($thumb_w ? " width=\"$thumb_w\"" : '');
-            $url = pagelinkurl(array(
-                'c'       => $c,
-                'context' => 'image',
-                's'       => $s,
-                'p'       => $id,
-            ));
-            $out[] = href(
-                '<img src="'.imagesrcurl($id, $ext, true).'"'.$dims.' alt="'.txpspecialchars($alt).'" />',
-                $url
-            );
-        }
-
-        if (count($out)) {
-            return doLabel($label, $labeltag).doWrap($out, $wraptag, $break, $class);
-        }
+    if (!isset($atts['class'])) {
+        $atts['class'] = __FUNCTION__;
     }
-
+    
+    if ($atts['category']) {
+        return images($atts);
+    }
+    
     return '';
 }
 
@@ -3299,21 +3277,12 @@ function image_index($atts)
 
 function image_display($atts)
 {
-    if (is_array($atts)) {
-        extract($atts);
-    }
-
+    trigger_error(gTxt('deprecated_tag'), E_USER_NOTICE);
+    
     global $p;
 
     if ($p) {
-        $rs = safe_row("*", 'txp_image', "id=".intval($p)." LIMIT 1");
-
-        if ($rs) {
-            extract($rs);
-
-            return '<img src="'.imagesrcurl($id, $ext).
-                '" style="height:'.$h.'px;width:'.$w.'px" alt="'.txpspecialchars($alt).'" />';
-        }
+        return image(array('id' => $p));
     }
 }
 

--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -3580,8 +3580,6 @@ function images($atts, $thing = null)
 
 function image_info($atts)
 {
-    global $thisimage;
-
     extract(lAtts(array(
         'name'       => '',
         'id'         => '',
@@ -3600,32 +3598,19 @@ function image_info($atts)
     $validItems = array('id', 'name', 'category', 'category_title', 'alt', 'caption', 'ext', 'author', 'w', 'h', 'thumb_w', 'thumb_h', 'date');
     $type = do_list($type);
 
-    $from_form = false;
-
-    if ($id) {
-        $thisimage = imageFetchInfo('id = '.intval($id));
-    } elseif ($name) {
-        $thisimage = imageFetchInfo("name = '".doSlash($name)."'");
-    } else {
-        assert_image();
-        $from_form = true;
-    }
-
     $out = array();
-    if ($thisimage) {
-        $thisimage['category_title'] = fetch_category_title($thisimage['category'], 'image');
+    if ($imageData = imageFetchInfo($id, $name)) {
+        $imageData['category_title'] = fetch_category_title($imageData['category'], 'image');
 
         foreach ($type as $item) {
             if (in_array($item, $validItems)) {
-                if (isset($thisimage[$item])) {
+                if (isset($imageData[$item])) {
                     $out[] = ($escape == 'html') ?
-                        txpspecialchars($thisimage[$item]) : $thisimage[$item];
+                        txpspecialchars($imageData[$item]) : $imageData[$item];
                 }
+            } else {
+                trigger_error(gTxt('invalid_attribute_value', array('{name}' => $item)), E_USER_NOTICE);
             }
-        }
-
-        if (!$from_form) {
-            $thisimage = '';
         }
     }
 
@@ -3636,8 +3621,6 @@ function image_info($atts)
 
 function image_url($atts, $thing = null)
 {
-    global $thisimage;
-
     extract(lAtts(array(
         'name'      => '',
         'id'        => '',
@@ -3645,28 +3628,11 @@ function image_url($atts, $thing = null)
         'link'      => 'auto',
     ), $atts));
 
-    $from_form = false;
-
-    if ($id) {
-        $thisimage = imageFetchInfo('id = '.intval($id));
-    } elseif ($name) {
-        $thisimage = imageFetchInfo("name = '".doSlash($name)."'");
-    } else {
-        assert_image();
-        $from_form = true;
-    }
-
-    if ($thisimage) {
-        $url = imagesrcurl($thisimage['id'], $thisimage['ext'], $thumbnail);
+    if ($imageData = imageFetchInfo($id, $name)) {
+        $url = imagesrcurl($imageData['id'], $imageData['ext'], $thumbnail);
         $link = ($link == 'auto') ? (($thing) ? 1 : 0) : $link;
         $out = ($thing) ? parse($thing) : $url;
-        $out = ($link) ? href($out, $url) : $out;
-
-        if (!$from_form) {
-            $thisimage = '';
-        }
-
-        return $out;
+        return ($link) ? href($out, $url) : $out;
     }
 
     return '';
@@ -3706,35 +3672,18 @@ function image_author($atts)
 
 function image_date($atts)
 {
-    global $thisimage;
-
     extract(lAtts(array(
         'name'   => '',
         'id'     => '',
         'format' => '',
     ), $atts));
 
-    $from_form = false;
-
-    if ($id) {
-        $thisimage = imageFetchInfo('id = '.intval($id));
-    } elseif ($name) {
-        $thisimage = imageFetchInfo("name = '".doSlash($name)."'");
-    } else {
-        assert_image();
-        $from_form = true;
-    }
-
-    if (isset($thisimage['date'])) {
+    if ($imageData = imageFetchInfo($id, $name)) {
         // Not a typo: use fileDownloadFormatTime() since it's fit for purpose.
         $out = fileDownloadFormatTime(array(
-            'ftime'  => $thisimage['date'],
+            'ftime'  => $imageData['date'],
             'format' => $format,
         ));
-
-        if (!$from_form) {
-            $thisimage = '';
-        }
 
         return $out;
     }

--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -340,11 +340,15 @@ function thumbnail($atts)
         'link'     => 0,
         'link_rel' => '',
         'name'     => '',
-        'poplink'  => 0, // Is this used?
+        'poplink'  => 0, // Deprecated, 4.7
         'style'    => '',
         'wraptag'  => '',
         'width'    => '',
     ), $atts));
+
+    if (isset($atts['poplink'])) {
+        trigger_error(gTxt('deprecated_attribute', array('{name}' => 'poplink')), E_USER_NOTICE);
+    }
 
     if ($imageData = imageFetchInfo($id, $name)) {
         extract($imageData);

--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -267,9 +267,6 @@ function css($atts)
 
 function image($atts)
 {
-    global $thisimage;
-    static $cache = array();
-
     extract(lAtts(array(
         'class'   => '',
         'escape'  => 'html',
@@ -282,38 +279,8 @@ function image($atts)
         'wraptag' => '',
     ), $atts));
 
-    if ($name) {
-        if (isset($cache['n'][$name])) {
-            $rs = $cache['n'][$name];
-        } else {
-            $name = doSlash($name);
-
-            $rs = safe_row("*", 'txp_image', "name = '$name' LIMIT 1");
-
-            $cache['n'][$name] = $rs;
-        }
-    } elseif ($id) {
-        if (isset($cache['i'][$id])) {
-            $rs = $cache['i'][$id];
-        } else {
-            $id = (int) $id;
-
-            $rs = safe_row("*", 'txp_image', "id = $id LIMIT 1");
-
-            $cache['i'][$id] = $rs;
-        }
-    } elseif ($thisimage) {
-        $id = (int) $thisimage['id'];
-        $rs = $thisimage;
-        $cache['i'][$id] = $rs;
-    } else {
-        trigger_error(gTxt('unknown_image'));
-
-        return;
-    }
-
-    if ($rs) {
-        extract($rs);
+    if ($imageData = imageFetchInfo($id, $name)) {
+        extract($imageData);
 
         if ($escape == 'html') {
             $alt = txpspecialchars($alt);
@@ -358,16 +325,12 @@ function image($atts)
 
         return $out;
     }
-
-    trigger_error(gTxt('unknown_image'));
 }
 
 // -------------------------------------------------------------
 
 function thumbnail($atts)
 {
-    global $thisimage;
-
     extract(lAtts(array(
         'class'    => '',
         'escape'   => 'html',
@@ -383,25 +346,8 @@ function thumbnail($atts)
         'width'    => '',
     ), $atts));
 
-    if ($name) {
-        $name = doSlash($name);
-
-        $rs = safe_row("*", 'txp_image', "name = '$name' LIMIT 1");
-    } elseif ($id) {
-        $id = (int) $id;
-
-        $rs = safe_row("*", 'txp_image', "id = $id LIMIT 1");
-    } elseif ($thisimage) {
-        $id = (int) $thisimage['id'];
-        $rs = $thisimage;
-    } else {
-        trigger_error(gTxt('unknown_image'));
-
-        return;
-    }
-
-    if ($rs) {
-        extract($rs);
+    if ($imageData = imageFetchInfo($id, $name)) {
+        extract($imageData);
 
         if ($thumbnail) {
             if ($escape == 'html') {
@@ -462,8 +408,6 @@ function thumbnail($atts)
             return $out;
         }
     }
-
-    trigger_error(gTxt('unknown_image'));
 }
 
 // -------------------------------------------------------------

--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -3248,7 +3248,7 @@ function image_index($atts)
 {
     trigger_error(gTxt('deprecated_tag'), E_USER_NOTICE);
     
-    global $s, $c;
+    global $c;
 
     extract(lAtts(array(
         'label'    => '',


### PR DESCRIPTION
… to include logic duplicated across image_data(), image_url(), and image_date(). Added error checking and caching. (NB: this changes the behavior of imageFetchInfo(). The 3 tags above are the only Txp functions using imageFetchInfo(), which has only been around since 4.6.0.)