### PR TITLE
Set Content-Security-Policy header from php

### DIFF
--- a/textpattern/.htaccess
+++ b/textpattern/.htaccess
@@ -1,3 +1,0 @@
-<IfModule mod_headers.c>
-    Header set Content-Security-Policy "frame-ancestors 'self'"
-</IfModule>

--- a/textpattern/include/txp_tag.php
+++ b/textpattern/include/txp_tag.php
@@ -34,6 +34,7 @@ if (!defined('txpinterface')) {
     die('txpinterface is undefined.');
 }
 
+header('Content-Security-Policy: '.CONTENT_SECURITY_POLICY);
 header('X-Frame-Options: '.X_FRAME_OPTIONS);
 header('X-UA-Compatible: '.X_UA_COMPATIBLE);
 

--- a/textpattern/lib/constants.php
+++ b/textpattern/lib/constants.php
@@ -487,7 +487,7 @@ if (!defined('X_FRAME_OPTIONS')) {
     define('X_FRAME_OPTIONS', 'SAMEORIGIN');
 }
 
-if (!defined('CONTENT-SECURITY-POLICY')) {
+if (!defined('CONTENT_SECURITY_POLICY')) {
     /**
      * Sets Content-Security-Policy HTTP header's value.
      * 
@@ -497,7 +497,7 @@ if (!defined('CONTENT-SECURITY-POLICY')) {
      * @package CSRF
      */
 
-    define('CONTENT-SECURITY-POLICY', "frame-ancestors 'self'");
+    define('CONTENT_SECURITY_POLICY', "frame-ancestors 'self'");
 }
 
 if (!defined('X_UA_COMPATIBLE')) {

--- a/textpattern/lib/constants.php
+++ b/textpattern/lib/constants.php
@@ -487,6 +487,19 @@ if (!defined('X_FRAME_OPTIONS')) {
     define('X_FRAME_OPTIONS', 'SAMEORIGIN');
 }
 
+if (!defined('CONTENT-SECURITY-POLICY')) {
+    /**
+     * Sets Content-Security-Policy HTTP header's value.
+     * 
+     * This constant can be overridden from the config.php.
+     * 
+     * @since   4.7.0
+     * @package CSRF
+     */
+
+    define('CONTENT-SECURITY-POLICY', "frame-ancestors 'self'");
+}
+
 if (!defined('X_UA_COMPATIBLE')) {
     /**
      * Sets X-UA-Compatible HTTP header's value.

--- a/textpattern/lib/txplib_head.php
+++ b/textpattern/lib/txplib_head.php
@@ -78,6 +78,7 @@ function pagetop($pagetitle, $message = '')
         $body_id = 'page-'.txpspecialchars($event);
     }
 
+    header('Content-Security-Policy: '.CONTENT_SECURITY_POLICY);
     header('X-Frame-Options: '.X_FRAME_OPTIONS);
     header('X-UA-Compatible: '.X_UA_COMPATIBLE);
 


### PR DESCRIPTION
Issue #408
* Reduces the mix of headers (.htaccess/php).
* It is possible to set the header under the nginx and other web servers.