### PR TITLE
Switch gTxt `invalid_expirydate` to `invalid_expiredate`

### DIFF
--- a/textpattern/include/txp_article.php
+++ b/textpattern/include/txp_article.php
@@ -260,7 +260,7 @@ function article_save()
 
         if ($ts === false || $ts < 0) {
             $expires = $oldArticle['sExpires'];
-            $msg = array(gTxt('invalid_expirydate'), E_ERROR);
+            $msg = array(gTxt('invalid_expiredate'), E_ERROR);
         } else {
             $expires = $ts - tz_offset($ts);
         }


### PR DESCRIPTION
Uniformity: gTxt strings refer to 'expire' (multiple mentions), not 'expiry' (zero mentions).

There's a request for addition in Textpacks (https://github.com/textpattern/textpacks/issues/217), but if we can change this out then the more appropriate gTxt (`invalid_expiredate`) can be added to be a better fit.

(Please and thank you.)