### PR TITLE
Adds Skin package (includes txp_skin.php changes)

### DIFF
--- a/textpattern/vendors/Textpattern/Skin/AssetBase.php
+++ b/textpattern/vendors/Textpattern/Skin/AssetBase.php
@@ -1,0 +1,515 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * https://textpattern.io/
+ *
+ * Copyright (C) 2017 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * AssetBase
+ *
+ * Extended by Pages, Forms, Styles…
+ *
+ * @since   4.7.0
+ * @package Skin
+ * @see     SkinBase, SkinInterface
+ */
+
+namespace Textpattern\Skin {
+
+    abstract class AssetBase extends SkinBase implements SkinInterface
+    {
+        /**
+         * The asset related table.
+         *
+         * @var string
+         */
+
+        protected static $table;
+
+        /**
+         * The asset related default templates
+         * to use on skin creation.
+         *
+         * @var array
+         */
+
+        protected static $essential;
+
+        /**
+         * The asset related skin subdirectory.
+         *
+         * @var string
+         */
+
+        protected static $dir;
+
+        /**
+         * The max depth (or number of nested subdirectories)
+         * used to store the asset related templates
+         * in the above directory.
+         *
+         * @var string
+         */
+
+        protected static $depth = 0;
+
+        /**
+         * The valid asset related files extension.
+         *
+         * @var string
+         */
+
+        protected static $extension = 'txp';
+
+        /**
+         * The asset related template names to work with
+         * (all templates by default).
+         *
+         * @var array
+         */
+
+        protected $templates = array();
+
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function __construct($skin = null, $infos = null, $templates = null)
+        {
+            parent::__construct($skin, $infos);
+
+            if ($templates) {
+                $this->templates = is_array($templates) ? $templates : array($templates);
+            }
+        }
+
+        public static function getEssential()
+        {
+            return static::$essential;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function create()
+        {
+            if ($this->skinIsInstalled()) {
+                $templates = $this->templates ? $this->templates : static::$essential;
+                $sql_values = $this->getCreationSQLValues($templates);
+
+                $callback_extra = array(
+                    'skin'      => strtolower(sanitizeForUrl($this->skin)),
+                    'templates' => $templates,
+                );
+
+                callback_event(static::$dir, 'create', 0, $callback_extra);
+
+                if ($this->insertTemplates(static::$columns, $sql_values)) {
+                    callback_event(static::$dir, 'created', 0, $callback_extra);
+                } else {
+                    callback_event(static::$dir, 'creation_failed', 0, $callback_extra);
+
+                    throw new \Exception($this->getFailureMessage('creation', $this->templates));
+                }
+            } else {
+                throw new \Exception('unknown_skin');
+            }
+        }
+
+        /**
+         * Gets an array of SQL VALUES sorted as the asset $columns property.
+         *
+         * @param  array $templates An array of templates names to create.
+         * @return array SQL VALUES
+         */
+
+        abstract protected function getCreationSQLValues($templates);
+
+        /**
+         * {@inheritdoc}
+         */
+        public function edit()
+        {
+            $callback_extra = array(
+                'skin'      => $this->skin,
+                'templates' => $this->templates,
+            );
+
+            callback_event(static::$dir, 'import', 0, $callback_extra);
+
+            $updated = (bool) safe_update(
+                static::$table,
+                "skin = '".doSlash(strtolower(sanitizeForUrl($this->infos['new_name'])))."'",
+                "skin = '".doSlash($this->skin)."'"
+            );
+
+            if ($updated) {
+                callback_event(static::$dir, 'edited', 0, $callback_extra);
+
+                return;
+            }
+
+            callback_event(static::$dir, 'edit_failed', 0, $callback_extra);
+
+            throw new \Exception($this->getFailureMessage('edit', $failed));
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function import($clean = true)
+        {
+            if ($this->skinIsInstalled()) {
+                $was_locked = $this->locked;
+
+                if ($this->isReadable(static::$dir) && $this->lockSkin()) {
+                    $files = $this->getRecDirIterator();
+                    $passed = $failed = $sql_values = array();
+
+                    foreach ($files as $file) {
+                        $name = $file->getTemplateName();
+
+                        if (!in_array($name, $passed)) {
+                            $passed[] = $name;
+                            $sql_values[] = $this->getImportSQLValue($file);
+                        } else {
+                            $failed[] = $name; // Duplicated form.
+                        }
+                    }
+
+                    $was_locked ?: $this->unlockSkin();
+
+                    $callback_extra = array(
+                        'skin'      => $this->skin,
+                        'templates' => $passed,
+                    );
+
+                    callback_event(static::$dir, 'import', 0, $callback_extra);
+
+                    if ($sql_values) {
+                        if ($this->insertTemplates(static::$columns, $sql_values, true)) {
+                            callback_event(static::$dir, 'imported', 0, $callback_extra);
+
+                            $clean ? $this->dropRemovedFiles($passed) : '';
+
+                            if ($failed) {
+                                throw new \Exception(
+                                    $this->getFailureMessage(
+                                        'import',
+                                        $failed,
+                                        'skin_step_failed_for_duplicated_templates'
+                                    )
+                                );
+                            }
+                        } else {
+                            callback_event(static::$dir, 'import_failed', 0, $callback_extra);
+
+                            throw new \Exception(
+                                $this->getFailureMessage('import', $passed)
+                            );
+                        }
+                    }
+                }
+            } else {
+                throw new \Exception('unknown_skin');
+            }
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function getRecDirIterator()
+        {
+            return new RecIteratorIterator(
+                new RecFilterIterator(
+                    new RecDirIterator($this->getPath(static::$dir)),
+                    static::$extension,
+                    $this->templates
+                ),
+                static::$depth
+            );
+        }
+
+        /**
+         * Gets an SQL VALUE sorted as the asset $columns property.
+         *
+         * @param  RecDirIterator $file.
+         * @return string SQL VALUE (a VALUES item).
+         */
+
+        abstract protected function getImportSQLValue(RecDirIterator $file);
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function insertTemplates($fields, $values, $update = false)
+        {
+
+            if ($update) {
+                $updates = array();
+
+                foreach ($fields as $field) {
+                    $updates[] = $field.'=VALUES('.$field.')';
+                }
+
+                $update = 'ON DUPLICATE KEY UPDATE '.implode(', ', $updates);
+            }
+
+            return (bool) safe_query(
+                sprintf(
+                    'INSERT INTO '.safe_pfx(static::$table).' (%s) VALUES %s %s',
+                    implode(', ', $fields),
+                    implode(', ', $values),
+                    $update ? $update : ''
+                )
+            );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function dropRemovedFiles($not)
+        {
+            if ($not) {
+                $where = "name not in ('".implode("', '", array_map('doSlash', $not))."')";
+            } else {
+                $where = '1 = 1';
+            }
+
+            if ($drop = (bool) safe_delete(static::$table, $where)) {
+                return $drop;
+            }
+
+            throw new \Exception('unable_to_delete_obsolete_skin_templates');
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function update($clean = true)
+        {
+            return $this->import($clean);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function duplicate()
+        {
+            if ($this->skinIsInstalled(true)) {
+                if ($rows = $this->getTemplateRows()) {
+                    $templates = $sql_values = array();
+
+                    foreach ($rows as $row) {
+                        $templates[] = $row['name'];
+                        $row['skin'] = strtolower(sanitizeForUrl($row['skin'].$this->stamp));
+                        $sql_fields ?: $sql_fields = array_keys($row);
+                        $sql_values[] = "('".implode("', '", array_map('doSlash', $row))."')";
+                    }
+
+                    $callback_extra = array(
+                        'skin'      => $this->skin,
+                        'templates' => $templates,
+                    );
+
+                    callback_event(static::$dir, 'duplicate', 0, $templates);
+
+                    if ($sql_fields && $sql_values) {
+                        if ($this->insertTemplates($sql_fields, $sql_values)) {
+                            callback_event(static::$dir, 'duplicated', 0, $callback_extra);
+                        } else {
+                            callback_event(static::$dir, 'duplication_failed', 0, $callback_extra);
+
+                            throw new \Exception(
+                                $this->getFailureMessage('duplication', $templates)
+                            );
+                        }
+                    }
+                }
+            } else {
+                throw new \Exception('unknown_skin');
+            }
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function getTemplateRows()
+        {
+            return safe_rows('*', static::$table, $this->getWhereClause());
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function getWhereClause()
+        {
+            $where = "skin = '".doSlash($this->skin)."'";
+
+            if ($this->templates) {
+                $where .= ' AND name in ("'.implode('", "', array_map('doSlash', $this->templates)).'")';
+            }
+
+            return $where;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function export($clean = true, $copy = false)
+        {
+            if ($rows = $this->getTemplateRows()) {
+                $was_locked = $this->locked;
+
+                if ($this->lockSkin() && ($this->isWritable(static::$dir) || $this->mkDir(static::$dir))) {
+                    $callback_extra = array(
+                        'skin'      => $this->skin,
+                        'templates' => $this->templates,
+                    );
+
+                    callback_event(static::$dir, 'export', 0, $callback_extra);
+
+                    $passed = $failed = array();
+
+                    foreach ($rows as $row) {
+                        if ($this->exportTemplate($row)) {
+                            $passed[] = $row['name'];
+                        } else {
+                            $failed[] = $row['name'];
+                        }
+                    }
+
+                    $was_locked ?: $this->unlockSkin();
+
+                    if ($passed) {
+                        $callback_extra['templates'] = $passed;
+
+                        callback_event(static::$dir, 'exported', 0, $callback_extra);
+
+                        $clean ? $this->unlinkRemovedRows($passed) : '';
+                    }
+
+                    if ($failed) {
+                        $callback_extra['templates'] = $failed;
+
+                        callback_event(static::$dir, 'export_failed', 0, $callback_extra);
+
+                        throw new \Exception(
+                            $this->getFailureMessage('export', $failed)
+                        );
+                    }
+                }
+            }
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        abstract public function exportTemplate($row);
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function unlinkRemovedRows($not)
+        {
+            $files = $this->getRecDirIterator();
+
+            foreach ($files as $file) {
+                $name = $file->getTemplateName();
+
+                if (!$not || ($not && !in_array($name, $not))) {
+                    unlink($file->getPathname());
+                }
+            }
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function delete()
+        {
+            if ($rows = $this->getTemplateRows()) {
+                $templates = array();
+
+                foreach ($rows as $row) {
+                    $templates[] = $row['name'];
+                }
+
+                $callback_extra = array(
+                    'skin'      => $this->skin,
+                    'templates' => $templates,
+                );
+
+                callback_event(static::$dir, 'delete', 0, $callback_extra);
+
+                if ($this->deleteTemplates()) {
+                    callback_event(static::$dir, 'deleted', 0, $callback_extra);
+                } else {
+                    callback_event(static::$dir, 'deletion_failed', 0, $callback_extra);
+
+                    throw new \Exception($this->getFailureMessage('deletion', $templates));
+                }
+            }
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function deleteTemplates()
+        {
+            return (bool) safe_delete(doSlash(static::$table), $this->getWhereClause());
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        private function getFailureMessage(
+            $process,
+            $templates,
+            $message = 'skin_step_failed_for_templates'
+        ) {
+            return gtxt(
+                $message,
+                array(
+                    '{skin}'      => $this->skin,
+                    '{asset}'     => static::$dir,
+                    '{step}'      => $process,
+                    '{templates}' => implode(', ', $templates),
+                )
+            );
+        }
+    }
+}

--- a/textpattern/vendors/Textpattern/Skin/AssetInterface.php
+++ b/textpattern/vendors/Textpattern/Skin/AssetInterface.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * https://textpattern.io/
+ *
+ * Copyright (C) 2017 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Asset Interface
+ *
+ * Implemented by AssetBase
+ *
+ * @since   4.7.0
+ * @package Skin
+ * @see     MainInterface
+ */
+
+namespace Textpattern\Skin {
+
+    interface AssetInterface extends MainInterface
+    {
+        /**
+         * Constructor
+         *
+         * @param string       $skin      The asset related skin name (set the related parent property)
+         * @param string       $stamp     The asset related skin infos (set the related parent property)
+         * @param string|array $templates Restricts import to provided template name(s)
+         */
+
+        public function __construct($skin = null, $infos = null, $templates = null);
+
+        /**
+         * Get the essential/default templates.
+         *
+         * @return array Template names (or names => type for forms).
+         */
+
+        public static function getEssential();
+
+        /**
+         * Gets a new asset iterator instance.
+         *
+         * @return RecursiveIteratorIterator
+         */
+
+        public function getRecDirIterator();
+
+        /**
+         * Inserts or updates all asset related templates at once.
+         *
+         * @param  array $fields The template related database fields;
+         * @param  array $values SQL VALUES as an array of group of values;
+         * @param  bool  $update Whether to update rows on duplicate keys or not;
+         * @return bool  False on error.
+         */
+
+        public function insertTemplates($fields, $values, $update = false);
+
+        /**
+         * Drops obsolete template rows.
+         *
+         * @param  array $not An array of template names to NOT drop;
+         * @return bool  False on error.
+         */
+
+        public function dropRemovedFiles($not);
+
+        /**
+         * Get skin asset related templates rows.
+         *
+         * @throws \Exception
+         */
+
+        public function getTemplateRows();
+
+        /**
+         * Exports a skin asset related template row.
+         *
+         * @param  array      $row A template row as an associative array
+         * @throws \Exception
+         */
+
+        public function exportTemplate($row);
+
+        /**
+         * Unlinks obsolete template files.
+         *
+         * @param  array $not An array of template names to NOT unlink;
+         * @return bool  False on error.
+         */
+
+        public function unlinkRemovedRows($not);
+
+        /**
+         * Deletes skin asset related template rows.
+         *
+         * @throws \Exception
+         */
+
+        public function deleteTemplates();
+    }
+}

--- a/textpattern/vendors/Textpattern/Skin/Forms.php
+++ b/textpattern/vendors/Textpattern/Skin/Forms.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * https://textpattern.io/
+ *
+ * Copyright (C) 2017 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Forms
+ *
+ * Manages skin forms directly or via the Skin class.
+ *
+ * @since   4.7.0
+ * @package Skin
+ * @see     AssetInterface
+ */
+
+namespace Textpattern\Skin {
+
+    class Forms extends Pages
+    {
+        protected static $dir = 'forms';
+        protected static $depth = 1; // Forms stored by type in subfolders.
+        protected static $table = 'txp_form';
+        protected static $columns = array('skin', 'name', 'type', 'Form');
+        protected static $essential = array(
+            'comments'         => 'comment',
+            'comments_display' => 'comment',
+            'comment_form'     => 'comment',
+            'default'          => 'article',
+            'plainlinks'       => 'link',
+            'files'            => 'file',
+        );
+
+        /**
+         * {@inheritdoc}
+         */
+
+        protected function getCreationSQLValues($templates)
+        {
+            $sql = array();
+
+            foreach ($templates as $name => $type) {
+                $sql[] = "("
+                  ."'".doSlash(strtolower(sanitizeForUrl($this->skin)))."', "
+                  ."'".doSlash($name)."', "
+                  ."'".doSlash($type)."', "
+                  ."''"
+                  .")";
+            }
+
+            return $sql;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        protected function getImportSQLValue(RecDirIterator $file)
+        {
+            return "("
+                ."'".doSlash($this->skin)."', "
+                ."'".doSlash($file->getTemplateName())."', "
+                ."'".doSlash($file->getTemplateType())."', "
+                ."'".doSlash($file->getTemplateContents())."'"
+                .")";
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function exportTemplate($row)
+        {
+            extract($row);
+
+            $path = static::$dir.'/'.$type;
+
+            if ($this->isWritable($path) || $this->mkDir($path)) {
+                return (bool) file_put_contents(
+                    $this->getPath($path.'/'.$name.'.'.static::$extension),
+                    $Form
+                );
+            }
+        }
+    }
+}

--- a/textpattern/vendors/Textpattern/Skin/Main.php
+++ b/textpattern/vendors/Textpattern/Skin/Main.php
@@ -1,0 +1,302 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * https://textpattern.io/
+ *
+ * Copyright (C) 2017 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Main
+ *
+ * Manages the Skin admin tab features.
+ *
+ * @since   4.7.0
+ * @package Skin
+ */
+ 
+namespace Textpattern\Skin {
+
+    class Main extends MainBase implements MainInterface
+    {
+        /**
+         * Stores skin(s) instances.
+         *
+         * @var array
+         */
+
+        protected $skins = array();
+
+        /**
+         * Constructor.
+         *
+         * @param array        $skins  Associative array of the skin(s) and their related edit infos.
+         * @param string|array $assets Asset, array of assets or associative array of asset(s)
+         *                             and its/their related template(s) to work with.
+         */
+
+        public function __construct($skins, $assets = array('pages', 'forms', 'styles'))
+        {
+            foreach ($skins as $skin => $infos) {
+                $this->skins[$skin] = \Txp::get('Textpattern\Skin\Skin', $skin, $infos, $assets);
+            }
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function create()
+        {
+            return $this->callSkinsMethod(__FUNCTION__);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function edit()
+        {
+            return $this->callSkinsMethod(__FUNCTION__);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function duplicate()
+        {
+            return $this->callSkinsMethod(__FUNCTION__);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function import($clean = true)
+        {
+            return $this->callSkinsMethod(__FUNCTION__, func_get_args());
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function update($clean = true)
+        {
+            return $this->callSkinsMethod(__FUNCTION__, func_get_args());
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function export($clean = true, $copy = false)
+        {
+            return $this->callSkinsMethod(__FUNCTION__, func_get_args());
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function delete()
+        {
+            return $this->callSkinsMethod(__FUNCTION__);
+        }
+
+        /**
+         * Iterates skins and calls the defined Skin class method.
+         *
+         * @param  string $method A Skin class method name.
+         * @param  array  $args   Array of arguments to pass to the defined method.
+         * @return string The UI message to display.
+         */
+
+        private function callSkinsMethod($method, $args = array())
+        {
+            $done = substr($method, -1) === 'e' ? 'd' : 'ed';
+            $results = array();
+
+            foreach ($this->skins as $skin => $instance) {
+                try {
+                    call_user_func_array(array($instance, $method), $args);
+
+                    $results[$skin]['success'][] = gtxt(
+                        'skin_step_succeeded',
+                        array('{step}' => $method.$done)
+                    );
+                } catch (\Exception $e) {
+                    $results[$skin]['error'][] = $e->getMessage();
+                }
+            }
+
+            return self::getUIMessage($results);
+        }
+
+        /**
+         * Builds the UI message to display.
+         *
+         * @param  array  $results Associative array of the skin(s)
+         *                         and their success/failure messages.
+         * @return string The UI message to display.
+         * @see callSkinsMethod().
+         */
+
+        public static function getUIMessage($results)
+        {
+            $out = array();
+            $status = null;
+
+            foreach ($results as $skin => $result) {
+                if (array_key_exists('error', $result) || $status === 'E_ERROR') {
+                    if ($status && array_key_exists('success', $result)) {
+                        $status = 'E_WARNING';
+                    } else {
+                        $status = 'E_ERROR';
+                    }
+                }
+
+                foreach ($result as $severity => $messages) {
+                    foreach ($messages as $message) {
+                        if (array_key_exists($message, $out) && $severity === 'success') {
+                            $out[$message] .= ', '.$skin;
+                        } else {
+                            $out[$message] = $message.($severity === 'success' ? ' '.$skin : '');
+                        }
+                    }
+                }
+            }
+
+            $out = implode('<br>', $out);
+
+            return $status ? array($out, constant($status)) : $out;
+        }
+
+        /**
+         * Gets the skin import form.
+         *
+         * @return html The form or a message if no new skin directory is found.
+         */
+
+        public static function renderImportForm()
+        {
+            if ($new = self::getNewDirectories()) {
+                return n.
+                    tag_start('form', array(
+                        'id'     => 'skin_import_form',
+                        'name'   => 'skin_import_form',
+                        'method' => 'post',
+                        'action' => 'index.php',
+                    )).
+                    tag(gTxt('import_skin'), 'label', array('for' => 'skin_import')).
+                    popHelp('skin_import').
+                    selectInput('skins', $new, '', true, true, 'skins').
+                    eInput('skin').
+                    sInput('import').
+                    n.
+                    tag_end('form');
+            } else {
+                return '<span>'.gtxt('no_new_skin_to_import').'</span>';
+            }
+        }
+
+        /**
+         * Gets an array of the available skin directories.
+         *
+         * Skin directories name must be in lower cases
+         * and sanitized for URL to appears in the select list.
+         * Theses directories also need to contain a composer.json file
+         * to get the skin title from the 'name' JSON field.
+         *
+         * @return array Associative array of skin names and their related title.
+         */
+
+        public static function getDirectories()
+        {
+            if (static::$directories === null) {
+                $skins = self::getRecDirIterator();
+                static::$directories = array();
+
+                foreach ($skins as $skin) {
+                    $name = basename($skin->getPath());
+
+                    if ($name === strtolower(sanitizeForUrl($name))) {
+                        $infos = $skin->getTemplateJSONContents();
+                        static::$directories[$name] = $infos['name'];
+                    }
+                }
+            }
+
+            return static::$directories;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public static function getRecDirIterator()
+        {
+            return new RecIteratorIterator(
+                new RecFilterIterator(
+                    new RecDirIterator(get_pref('skin_base_path')),
+                    'json',
+                    'composer'
+                ),
+                1
+            );
+        }
+
+        /**
+         * Gets an array of the new — not imported yet — skin directories.
+         *
+         * @return array Associative array of skin names and their related title.
+         */
+
+        public static function getNewDirectories()
+        {
+            return array_diff_key(
+                self::getDirectories(),
+                self::getInstalled()
+            );
+        }
+
+        /**
+         * Gets an array of the installed skins.
+         *
+         * @return array Associative array of skin names and their related title.
+         */
+
+        public static function getInstalled()
+        {
+            if (static::$installed === null) {
+                if (!empty($skins = safe_rows('name, title', 'txp_skin', "1=1"))) {
+                    static::$installed = array();
+
+                    foreach ($skins as $skin) {
+                        static::$installed[$skin['name']] = $skin['title'];
+                    }
+                } else {
+                    throw new \Exception('empty_skin_table');
+                }
+            }
+
+            return static::$installed;
+        }
+    }
+}

--- a/textpattern/vendors/Textpattern/Skin/MainBase.php
+++ b/textpattern/vendors/Textpattern/Skin/MainBase.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * https://textpattern.io/
+ *
+ * Copyright (C) 2017 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Main Base
+ *
+ * Extended by Main and skinBase.
+ *
+ * @since   4.7.0
+ * @package Skin
+ */
+ 
+namespace Textpattern\Skin {
+
+    abstract class MainBase implements MainInterface
+    {
+        /**
+         * Caches the installed skins.
+         *
+         * @var array Associative array of skin names and their related title.
+         * @see Main::getInstalled()
+         */
+
+        protected static $installed = null;
+
+        /**
+         * Caches the uploaded skin directories.
+         *
+         * @var array Associative array of skin names and their related title.
+         * @see Main::getDirectories()
+         */
+
+        protected static $directories = null;
+
+        /**
+         * {@inheritdoc}
+         */
+
+        abstract public function create();
+
+        /**
+         * {@inheritdoc}
+         */
+
+        abstract public function edit();
+
+        /**
+         * {@inheritdoc}
+         */
+
+        abstract public function duplicate();
+
+        /**
+         * {@inheritdoc}
+         */
+
+        abstract public function import($clean = true);
+
+        /**
+         * {@inheritdoc}
+         */
+
+        abstract public function update($clean = true);
+
+        /**
+         * {@inheritdoc}
+         */
+
+        abstract public function export($clean = true, $copy = false);
+
+        /**
+         * {@inheritdoc}
+         */
+
+        abstract public function delete();
+    }
+}

--- a/textpattern/vendors/Textpattern/Skin/MainInterface.php
+++ b/textpattern/vendors/Textpattern/Skin/MainInterface.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * https://textpattern.io/
+ *
+ * Copyright (C) 2017 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Main Interface
+ *
+ * Implemented by Main and SkinInterface.
+ *
+ * @since   4.7.0
+ * @package Skin
+ */
+ 
+namespace Textpattern\Skin {
+
+    interface MainInterface
+    {
+        /**
+         * Creates the skin(s) and/or its asset related templates.
+         *
+         * @throws \Exception
+         */
+
+        public function create();
+
+        /**
+         * Edits the skin(s) and/or its asset related templates.
+         *
+         * @throws \Exception
+         */
+
+        public function edit();
+
+        /**
+         * Creates a time stamped copy of the skin(s) and/or its asset related template rows.
+         *
+         * @throws \Exception
+         */
+
+        public function duplicate();
+
+        /**
+         * Imports the skin(s) and/or its asset related templates from the related directory(ies).
+         *
+         * @param  bool $clean whether to remove obsolete files or not.
+         * @throws \Exception
+         */
+
+        public function import($clean = true);
+
+        /**
+         * Updates/overrides the skin(s) and/or its asset related templates from the related directory(ies).
+         *
+         * @param  bool $clean whether to remove obsolete files or not.
+         * @throws \Exception
+         */
+
+        public function update($clean = true);
+
+        /**
+         * Exports the skin(s) and/or its asset related templates from the database.
+         *
+         * @param  bool $clean whether to remove obsolete files or not.
+         * @param  bool $copy whether to time stamped the exported directory or not.
+         * @throws \Exception
+         */
+
+        public function export($clean = true, $copy = false);
+
+        /**
+         * Deletes The skin and/or its asset related templates.
+         *
+         * @throws \Exception
+         */
+
+        public function delete();
+    }
+}

--- a/textpattern/vendors/Textpattern/Skin/Pages.php
+++ b/textpattern/vendors/Textpattern/Skin/Pages.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * https://textpattern.io/
+ *
+ * Copyright (C) 2017 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Pages
+ *
+ * Manages skin pages directly or via the Skin class.
+ *
+ * @since   4.7.0
+ * @package Skin
+ * @see     AssetInterface
+ */
+
+namespace Textpattern\Skin {
+
+    class Pages extends AssetBase
+    {
+        protected static $dir = 'pages';
+        protected static $table = 'txp_page';
+        protected static $columns = array('skin', 'name', 'user_html');
+        protected static $essential = array('default', 'error_default');
+
+        /**
+         * {@inheritdoc}
+         */
+
+        protected function getCreationSQLValues($templates)
+        {
+            $sql = array();
+
+            foreach ($templates as $name) {
+                $sql[] = "("
+                    ."'".doSlash(strtolower(sanitizeForUrl($this->skin)))."', "
+                    ."'".doSlash($name)."', "
+                    ."''"
+                    .")";
+            }
+
+            return $sql;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        protected function getImportSQLValue(RecDirIterator $file)
+        {
+            return "("
+                ."'".doSlash($this->skin)."', "
+                ."'".doSlash($file->getTemplateName())."', "
+                ."'".doSlash($file->getTemplateContents())."'"
+                .")";
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function exportTemplate($row)
+        {
+            extract($row);
+
+            return (bool) file_put_contents(
+                $this->getPath(static::$dir.'/'.$name.'.'.static::$extension),
+                $user_html
+            );
+        }
+    }
+}

--- a/textpattern/vendors/Textpattern/Skin/RecDirIterator.php
+++ b/textpattern/vendors/Textpattern/Skin/RecDirIterator.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * https://textpattern.io/
+ *
+ * Copyright (C) 2017 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * AssetIterator
+ *
+ * This class iterates over template files.
+ *
+ * <code>
+ * $templates = new RecursiveIteratorIterator(
+ *     new AssetFilterIterator(
+ *         new TemplateIterator('/path/to/dir')
+ *     )
+ * );
+ * foreach ($templates as $template) {
+ *     $template->getTemplateName();
+ *     $template->getTemplateContents();
+ * }
+ * </code>
+ *
+ * @since   4.7.0
+ * @package Skin
+ * @see \RecursiveDirectoryIterator
+ */
+
+namespace Textpattern\Skin {
+
+    class RecDirIterator extends \RecursiveDirectoryIterator
+    {
+        /**
+         * {@inheritdoc}
+         */
+
+        public function __construct($path, $flags = null)
+        {
+            if ($flags === null) {
+                $flags = \FilesystemIterator::FOLLOW_SYMLINKS |
+                         \FilesystemIterator::CURRENT_AS_SELF |
+                         \FilesystemIterator::SKIP_DOTS;
+            }
+
+            parent::__construct($path, $flags);
+        }
+
+        /**
+         * Gets the template contents.
+         *
+         * @throws \Exception
+         */
+
+        public function getTemplateContents()
+        {
+            if (($contents = file_get_contents($this->getPathname())) !== false) {
+                return preg_replace('/[\r|\n]+$/', '', $contents);
+            }
+
+            throw new \Exception('Unable to read: '.$this->getTemplateName());
+        }
+
+        /**
+         * Gets JSON file contents as an object.
+         *
+         * @return array
+         * @throws Exception
+         */
+
+        public function getTemplateJSONContents()
+        {
+            if (($file = $this->getTemplateContents()) && $file = @json_decode($file, true)) {
+                return $file;
+            }
+            throw new Exception('Invalid JSON file.');
+        }
+
+        /**
+         * Gets the template name.
+         *
+         * @return string
+         */
+
+        public function getTemplateName()
+        {
+            return pathinfo($this->getFilename(), PATHINFO_FILENAME);
+        }
+
+        /**
+         * Gets the form Type from its path.
+         *
+         * @return string
+         */
+
+        public function getTemplateType()
+        {
+            $types = array_keys(\get_form_types());
+            $type = basename($this->getPath());
+
+            if (in_array($type, $types)) {
+                return $type;
+            }
+
+            return 'misc';
+        }
+    }
+}

--- a/textpattern/vendors/Textpattern/Skin/RecFilterIterator.php
+++ b/textpattern/vendors/Textpattern/Skin/RecFilterIterator.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * https://textpattern.io/
+ *
+ * Copyright (C) 2017 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * AssetFilterIterator
+ *
+ * Filters asset iterator results.
+ *
+ * This class iterates over template files.
+ *
+ * <code>
+ * $filteredTemplates = new AssetFilterIterator(
+ *    AssetIterator('/path/to/dir')
+ * );
+ * </code>
+ *
+ * @since   4.7.0
+ * @package Skin
+ * @see     \RecursiveAssetFilterIterator
+ */
+
+namespace Textpattern\Skin {
+
+    class RecFilterIterator extends \RecursiveFilterIterator
+    {
+
+        /**
+         * Default regular expression pattern used
+         * to validate template filenames.
+         *
+         * @var string
+         */
+
+        protected static $filePattern = '/^[a-z][a-z0-9_\-\.]{0,63}\.(txp|html)$/i';
+
+        /**
+         * Array of template names used
+         * to validate template filenames.
+         *
+         * @var array
+         */
+
+        protected $templates = array();
+
+        /**
+         * Constructor
+         *
+         * @param RecDirIterator $iterator
+         * @param string        $extension
+         * @param string|array  $templates
+         */
+
+        public function __construct(
+            RecDirIterator $iterator,
+            $extension = null,
+            $templates = null
+        ) {
+            parent::__construct($iterator);
+
+            if (!empty($templates)) {
+                $this->templates = $templates;
+            }
+
+            if ($extension !== null && $extension !== 'txp') {
+                static::$filePattern = '/^[a-z][a-z0-9_\-\.]{0,63}\.('.$extension.')$/i';
+            }
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function accept()
+        {
+            return $this->isDir() || $this->isValidTemplate();
+        }
+
+        /**
+         * Validates a template file name.
+         *
+         * @return bool
+         */
+
+        public function isValidTemplate()
+        {
+            $isValid = false;
+
+            if (!$this->isDot() && $this->isReadable() && ($this->isFile() || $this->isLink())) {
+                $isValid = (bool) preg_match(
+                    static::$filePattern,
+                    $this->getFilename()
+                );
+
+                if ($isValid && $this->templates) {
+                    $isValid = in_array($this->getTemplateName(), $this->templates);
+                }
+            }
+
+            return $isValid;
+        }
+    }
+}

--- a/textpattern/vendors/Textpattern/Skin/RecIteratorIterator.php
+++ b/textpattern/vendors/Textpattern/Skin/RecIteratorIterator.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * https://textpattern.io/
+ *
+ * Copyright (C) 2017 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * AssetIterator
+ *
+ * This class iterates over template files.
+ *
+ * <code>
+ * $templates = new RecursiveIteratorIterator(
+ *     new AssetFilterIterator(
+ *         new TemplateIterator('/path/to/dir')
+ *     )
+ * );
+ * foreach ($templates as $template) {
+ *     $template->getTemplateName();
+ *     $template->getTemplateContents();
+ * }
+ * </code>
+ *
+ * @since   4.7.0
+ * @package Skin
+ * @see \RecursiveDirectoryIterator
+ */
+
+namespace Textpattern\Skin {
+
+    class RecIteratorIterator extends \RecursiveIteratorIterator
+    {
+        /**
+         * {@inheritdoc}
+         *
+         * @param int $depth Sets the MaxDepth property.
+         */
+
+        public function __construct(RecFilterIterator $iterator, $depth)
+        {
+            parent::__construct($iterator);
+            parent::setMaxDepth($depth);
+        }
+    }
+}

--- a/textpattern/vendors/Textpattern/Skin/Skin.php
+++ b/textpattern/vendors/Textpattern/Skin/Skin.php
@@ -1,0 +1,739 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * https://textpattern.io/
+ *
+ * Copyright (C) 2017 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Skin
+ *
+ * Manages a skin and its assets — pages, forms and styles by default.
+ *
+ * <code>
+ * Txp::get('Textpattern\Skin\Skin', abc_skin)->import();
+ * </code>
+ *
+ * @since   4.7.0
+ * @package Skin
+ */
+ 
+namespace Textpattern\Skin {
+
+    class Skin extends SkinBase implements SkinInterface
+    {
+
+        /**
+         * Skin infos as an associative array.
+         *
+         * @var array
+         */
+
+        protected static $table = 'txp_skin';
+
+        /**
+         * Skin infos file.
+         *
+         * @var array
+         */
+
+        protected static $file = 'composer.json';
+
+        /**
+         * Caches an associative array of assets and their related class instance.
+         *
+         * @var array
+         */
+
+        private $assets;
+
+        /**
+         * Constructor.
+         *
+         * @param string       $skin   The skin name (set the related parent property);
+         * @param array        $infos  Skin infos (set the related parent property).
+         * @param string|array $assets Asset, array of assets or associative array of asset(s)
+         *                             and its/their related template(s) to work with
+         *                             (Set the related property by caching the related instances).
+         */
+
+        public function __construct(
+            $skin = null,
+            $infos = null,
+            $assets = array('pages', 'forms', 'styles')
+        ) {
+            parent::__construct($skin, $infos);
+
+            if ($assets) {
+                $assets = $this->parseAssets($assets);
+
+                foreach ($assets as $asset => $templates) {
+                    $this->assets[$asset] = \Txp::get(
+                        'Textpattern\Skin\\'.ucfirst($asset),
+                        $skin,
+                        $infos,
+                        $templates
+                    );
+                }
+            }
+        }
+
+        /**
+         * Parses the $assets constructor argument.
+         *
+         * @param string|array $assets See __construct()
+         * @return array Associative array of assets and their relative templates.
+         */
+
+        private function parseAssets($assets)
+        {
+            if (!is_array($assets)) {
+                $assets = array($assets);
+            } elseif (isset($assets[0])) {
+                $assets = array_fill_keys($assets, array());
+            }
+
+            return $assets;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function create()
+        {
+            if (!$this->skinIsInstalled()) {
+                $callback_extra = array(
+                    'skin'   => $this->skin,
+                    'assets' => $this->assets,
+                );
+
+                callback_event('skin', 'creation', 0, $callback_extra);
+
+                if ($this->createSkin()) {
+                    $this->isInstalled = true;
+
+                    $this->assets ? $this->callAssetsMethod(__FUNCTION__) : '';
+
+                    callback_event('skin', 'created', 0, $callback_extra);
+                } else {
+                    callback_event('skin', 'creation_failed', 0, $callback_extra);
+
+                    throw new \Exception(
+                        gtxt(
+                            'skin_step_failed',
+                            array(
+                                '{skin}' => $this->skin,
+                                '{step}' => 'import',
+                            )
+                        )
+                    );
+                }
+            } else {
+                throw new \Exception('duplicated_skin');
+            }
+        }
+
+        /**
+         * Creates the skin row from $this->infos and some default values.
+         *
+         * @return bool False on error
+         */
+
+        public function createSkin()
+        {
+            extract($this->infos);
+
+            return (bool) safe_insert(
+                self::$table,
+                "title = '".doSlash($title ? $title : $this->skin)."',
+                 version = '".doSlash($version ? $version : '0.0.1')."',
+                 description = '".doSlash($description)."',
+                 author = '".doSlash($author ? $author : substr(cs('txp_login_public'), 10))."',
+                 website = '".doSlash($website)."',
+                 name = '".doSlash(strtolower(sanitizeForUrl($this->skin)))."'
+                "
+            );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function edit()
+        {
+            if ($this->skinIsInstalled()) {
+                if (!self::isInstalled($this->infos['new_name'])) {
+                    $sections = $this->isInUse();
+                    $callback_extra = array(
+                        'skin'   => $this->skin,
+                        'assets' => $this->assets,
+                    );
+
+                    callback_event('skin', 'edit', 0, $callback_extra);
+
+                    if ($this->editSkin()) {
+                        if ($sections) {
+                            safe_update(
+                                'txp_section',
+                                "skin = '".doSlash(strtolower(sanitizeForUrl($this->infos['new_name'])))."'",
+                                "skin = '".doSlash($this->skin)."'"
+                            );
+                        }
+
+                        $this->assets ? $this->callAssetsMethod(__FUNCTION__) : '';
+                        $this->skin = $this->infos['new_name'];
+
+                        callback_event('skin', 'edited', 0, $callback_extra);
+                    } else {
+                        callback_event('skin', 'edit_failed', 0, $callback_extra);
+
+                        throw new \Exception(
+                            gtxt(
+                                'skin_step_failed',
+                                array(
+                                    '{skin}' => $this->skin,
+                                    '{step}' => 'import',
+                                )
+                            )
+                        );
+                    }
+                } else {
+                    throw new \Exception('duplicted_skin');
+                }
+            } else {
+                throw new \Exception('unknown_skin');
+            }
+        }
+
+        /**
+         * Updates the skin row from $this->infos.
+         *
+         * @return bool False on error
+         */
+
+        public function editSkin()
+        {
+            extract($this->infos);
+
+            $update = (bool) safe_update(
+                self::$table,
+                "name = '".doSlash(strtolower(sanitizeForUrl($new_name)))."',
+                 title = '".doSlash($title ? $title : $new_name)."',
+                 version = '".doSlash($version)."',
+                 description = '".doSlash($description)."',
+                 author = '".doSlash($author)."',
+                 website = '".doSlash($website)."'
+                ",
+                "name = '".doSlash($this->skin)."'"
+            );
+
+            return $update;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function import($clean = true)
+        {
+            if (!$this->skinIsInstalled()) {
+                if ($this->isReadable(static::$file) && $this->lockSkin()) {
+                    $callback_extra = array(
+                        'skin'   => $this->skin,
+                        'assets' => $this->assets,
+                    );
+
+                    callback_event('skin', 'import', 0, $callback_extra);
+
+                    if ($this->importSkin()) {
+                        $this->isInstalled = true;
+
+                        $this->assets ? $this->callAssetsMethod(__FUNCTION__, func_get_args()) : '';
+
+                        $this->unlockSkin();
+
+                        callback_event('skin', 'imported', 0, $callback_extra);
+                    } else {
+                        $this->unlockSkin();
+
+                        callback_event('skin', 'import_failed', 0, $callback_extra);
+
+                        throw new \Exception(
+                            gtxt(
+                                'skin_step_failed',
+                                array(
+                                    '{skin}' => $this->skin,
+                                    '{step}' => 'import',
+                                )
+                            )
+                        );
+                    }
+                }
+            } else {
+                throw new \Exception('Unknown_skin');
+            }
+        }
+
+        /**
+         * Get and decodes the Composer file contents.
+         *
+         * @return array
+         * @throws \Exception
+         */
+
+        public function getJSONInfos()
+        {
+            $infos = @json_decode(
+                file_get_contents($this->getPath(static::$file)),
+                true
+            );
+
+            if ($infos) {
+                return $infos;
+            }
+
+            throw new \Exception(
+                gtxt('invalid_skin_json_file', array('{file}' => self::$file))
+            );
+        }
+
+        /**
+         * Imports the skin into the database from the Composer file contents.
+         *
+         * @return bool False on error
+         */
+
+        public function importSkin()
+        {
+            extract($this->getJSONInfos());
+
+            if ($authors) {
+                $author_list = array();
+
+                foreach ($authors as $author) {
+                    $author_list[] = $author['name'];
+                }
+            }
+
+            return (bool) safe_upsert(
+                self::$table,
+                "title = '".doSlash($name)."',
+                 version = '".doSlash($version)."',
+                 description = '".doSlash($description)."',
+                 author = '".doSlash(implode(', ', $author_list))."',
+                 website = '".doSlash($homepage)."'
+                ",
+                "name = '".doSlash($this->skin)."'"
+            );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function update($clean = true)
+        {
+            if ($this->skinIsInstalled()) {
+                if ($this->isReadable(static::$file) && $this->lockSkin()) {
+                    $callback_extra = array(
+                        'skin'   => $this->skin,
+                        'assets' => $this->assets,
+                    );
+
+                    callback_event('skin', 'update', 0, $callback_extra);
+
+                    if ($this->importSkin()) {
+                        $this->assets ? $this->callAssetsMethod(__FUNCTION__, func_get_args()) : '';
+
+                        $this->unlockSkin();
+
+                        callback_event('skin', 'updated', 0, $callback_extra);
+                    } else {
+                        $this->unlockSkin();
+
+                        callback_event('skin', 'update_failed', 0, $callback_extra);
+
+                        throw new \Exception(
+                            gtxt(
+                                'skin_step_failed',
+                                array(
+                                    '{skin}' => $this->skin,
+                                    '{step}' => 'update',
+                                )
+                            )
+                        );
+                    }
+                } else {
+                    throw new \Exception('Unknown_directory');
+                }
+            } else {
+                throw new \Exception('Unknown_skin');
+            }
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function duplicate()
+        {
+            if ($row = $this->getRow()) {
+                $this->setStamp();
+
+                $callback_extra = array(
+                    'skin'   => $this->skin,
+                    'stamp'  => $this->stamp,
+                    'assets' => $this->assets,
+                );
+
+                callback_event('skin', 'duplication', 0, $callback_extra);
+
+                if ($this->duplicateSkin($row)) {
+                    $this->assets ? $this->callAssetsMethod(__FUNCTION__) : '';
+
+                    callback_event('skin', 'duplicated', 0, $callback_extra);
+                } else {
+                    callback_event('skin', 'duplication_failed', 0, $callback_extra);
+
+                    throw new \Exception(
+                        gtxt(
+                            'skin_step_failed',
+                            array(
+                                '{skin}' => $this->skin,
+                                '{step}' => 'duplication',
+                            )
+                        )
+                    );
+                }
+            } else {
+                throw new \Exception('Unknown_skin');
+            }
+        }
+
+        /**
+         * Gets the skin row from the database.
+         *
+         * @throws \Exception
+         */
+
+        public function getRow()
+        {
+            if ($row = safe_row('*', self::$table, 'name = "'.doSlash($this->skin).'"')) {
+                return $row;
+            }
+
+            throw new \Exception(
+                gtxt('skin_not_found', array('{skin}' => $this->skin))
+            );
+        }
+
+        /**
+         * Duplicates the skin row.
+         *
+         * @param  array $row Skin row as an associative array
+         * @return bool  False on error
+         */
+
+        public function duplicateSkin($row)
+        {
+            $sql = array();
+
+            foreach ($row as $col => $value) {
+                if ($col === 'name') {
+                    $value = sanitizeForUrl($value.$this->stamp);
+                } elseif ($col === 'title') {
+                    $value = $value.$this->stamp;
+                }
+
+                $sql[] = $col." = '".doSlash($value)."'";
+            }
+
+            return (bool) safe_insert(self::$table, implode(', ', $sql));
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function export($clean = true, $copy = false)
+        {
+            if ($row = $this->getRow()) {
+                $copy ? $this->setStamp() : '';
+
+                $callback_extra = array(
+                    'skin'   => $this->skin,
+                    'stamp'  => $this->stamp,
+                    'assets' => $this->assets,
+                );
+
+                callback_event('skin', 'export', 0, $callback_extra);
+
+                if (($this->isWritable() || $this->mkDir()) && $this->lockSkin()) {
+                    if ($this->exportSkin($row)) {
+                        $this->assets ? $this->callAssetsMethod(__FUNCTION__, func_get_args()) : '';
+
+                        $this->unlockSkin();
+
+                        callback_event('skin', 'exported', 0, $callback_extra);
+                    } else {
+                        $this->unlockSkin();
+
+                        callback_event('skin', 'export_failed', 0, $callback_extra);
+
+                        throw new \Exception(
+                            gtxt(
+                                'skin_step_failed',
+                                array(
+                                    '{skin}' => $this->skin,
+                                    '{step}' => 'export',
+                                )
+                            )
+                        );
+                    }
+                }
+            } else {
+                throw new \Exception('Unknown_skin');
+            }
+        }
+
+        /**
+         * Exports the skin row by creating or editing the Composer file contents.
+         *
+         * @param  array $row Skin row as an associative array
+         * @return bool  False on error
+         */
+
+        public function exportSkin($row)
+        {
+            extract($row);
+
+            $contents = $this->isWritable(static::$file) ? $this->getJSONInfos() : array();
+
+            $contents['name'] = ($title ? $title : $name).' '.$this->stamp;
+            $description ? $contents['description'] = $description : '';
+            $version ? $contents['version'] = $version : '';
+            $website ? $contents['homepage'] = $website : '';
+
+            if ($author) {
+                $authors = explode(', ', $author);
+                $contents['authors'] ?: $contents['authors'] = array();
+
+                for ($i = 0, $count = count($authors); $i < $count; $i++) {
+                    $contents['authors'][$i]['name'] = $authors[$i];
+                }
+            }
+
+            return (bool) $this->filePutJsonContents($contents);
+        }
+
+        /**
+         * Creates/overrides the Composer file.
+         *
+         * @param  array $contents The composer file contents;
+         * @return bool  False on error.
+         */
+
+        public function filePutJsonContents($contents)
+        {
+            return (bool) file_put_contents(
+                $this->getPath(static::$file),
+                json_encode($contents, JSON_PRETTY_PRINT)
+            );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function delete()
+        {
+            if (!$this->skinIsInstalled()) {
+                throw new \Exception('Unknown_skin');
+            } elseif ($this->isInUse()) {
+                throw new \Exception(gtxt('unable_to_delete_skin_in_use', array('{skin}' => $this->skin)));
+            } elseif (count(Main::getInstalled()) < 1) {
+                throw new \Exception('unable_to_delete_the_only_skin');
+            } else {
+                $callback_extra = array(
+                    'skin'   => $this->skin,
+                    'assets' => $this->assets,
+                );
+
+                callback_event('skin', 'deletion', 0, $callback_extra);
+
+                $this->assets ? $this->callAssetsMethod(__FUNCTION__) : '';
+
+                if ($this->hasAssets()) {
+                    throw new \Exception('unable_to_delete_non_empty_skin');
+                } elseif ($this->deleteSkin()) {
+                    static::$installed = array_splice(static::$installed, $this->skin, 1);
+
+                    self::getCurrent() === $this->skin ? self::setCurrent($this->skin) : '';
+
+                    callback_event('skin', 'deleted', 0, $callback_extra);
+                } else {
+                    callback_event('skin', 'deletion_failed', 0, $callback_extra);
+
+                    throw new \Exception(
+                        gtxt(
+                            'skin_step_failed',
+                            array(
+                                '{skin}' => $this->skin,
+                                '{step}' => 'deletion',
+                            )
+                        )
+                    );
+                }
+            }
+        }
+
+        /**
+         * Deletes the skin row.
+         *
+         * @return bool  False on error.
+         */
+
+        public function deleteSkin()
+        {
+            return (bool) safe_delete(
+                doSlash(self::$table),
+                "name = '".doSlash($this->skin)."'"
+            );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function isInUse()
+        {
+            if ($this->skin) {
+                if ($this->isInUse === null) {
+                    $this->isInUse = safe_column(
+                        "name",
+                        'txp_section',
+                        "skin ='".doSlash($this->skin)."'"
+                    );
+                }
+
+                return $this->isInUse;
+            }
+
+            throw new \Exception('undefined_skin');
+        }
+
+        /**
+         * Checks if any template belongs to the skin.
+         *
+         * @return bool
+         * @throws \Exception
+         */
+
+        public function hasAssets()
+        {
+            if ($this->skin) {
+                $assets = safe_query(
+                    'SELECT p.name, f.name, c.name
+                     FROM '.safe_pfx('txp_page').' p,
+                          '.safe_pfx('txp_form').' f,
+                          '.safe_pfx('txp_css').' c 
+                     WHERE p.skin = "'.doSlash($this->skin).'" AND
+                           f.skin = "'.doSlash($this->skin).'" AND
+                           c.skin = "'.doSlash($this->skin).'"
+                    '
+                );
+
+                return @mysqli_num_rows($assets) > 0 ? true : false;
+            }
+
+            throw new \Exception('undefined_skin');
+        }
+
+        /**
+         * Gets the skin set as the one selected in the admin tabs.
+         *
+         * @return string The skin name
+         */
+
+        public static function getCurrent()
+        {
+            return get_pref('skin_editing', 'default');
+        }
+
+        /**
+         * Sets the skin as the one selected in the admin tabs.
+         *
+         * @param  string $skin A skin name.
+         * @throws \Exception
+         */
+
+        public static function setCurrent($skin = null)
+        {
+            $skin ?: $skin = safe_field('skin', 'txp_section', 'name = "default"');
+
+            if (set_pref('skin_editing', $skin, 'skin', PREF_HIDDEN, 'text_input', 0, PREF_PRIVATE) === false) {
+                throw new \Exception('unable_to_set_current_skin');
+            }
+        }
+
+        /**
+         * Sets the stamp property used for copies as skin name/title suffix.
+         */
+
+        private function setStamp()
+        {
+            $this->stamp = ' '.date('Y/m/d H:i:s');
+        }
+
+        /**
+         * Calls an asset class instance method.
+         *
+         * @param string $method An asset class related method;
+         * @param array  $args   An array to pass to the method;
+         * @throws \Exception
+         */
+
+        private function callAssetsMethod($method, $args = array())
+        {
+            $exceptions = array();
+
+            foreach ($this->assets as $asset => $instance) {
+                try {
+                    $instance->stamp = $this->stamp;
+                    $instance->locked = $this->locked;
+                    call_user_func_array(array($instance, $method), $args);
+                } catch (\Exception $e) {
+                    $exceptions[] = $e->getMessage();
+                }
+            }
+
+            if ($exceptions) {
+                $this->locked ? $this->unlockSkin() : '';
+
+                foreach ($this->assets as $asset => $instance) {
+                    $instance->stamp = $this->stamp;
+                    $instance->locked = $this->locked;
+                }
+
+                throw new \Exception(implode(n, $exceptions));
+            }
+        }
+    }
+}

--- a/textpattern/vendors/Textpattern/Skin/SkinBase.php
+++ b/textpattern/vendors/Textpattern/Skin/SkinBase.php
@@ -1,0 +1,272 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * https://textpattern.io/
+ *
+ * Copyright (C) 2017 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Skin Base
+ *
+ * Extended by Skin and AssetBase.
+ *
+ * @since   4.7.0
+ * @package Skin
+ */
+ 
+namespace Textpattern\Skin {
+
+    abstract class SkinBase extends MainBase implements SkinInterface
+    {
+        /**
+         * The skin to work with.
+         *
+         * @var string
+         */
+
+        protected $skin;
+
+        /**
+         * Caches whether the skin related row exists.
+         *
+         * @var bool
+         * @see isInstalled()
+         */
+
+        protected $isInstalled = null;
+
+        /**
+         * Caches whether the skin is used by any section.
+         *
+         * @var bool
+         * @see skinIsInUse()
+         */
+
+        protected $isInUse = null;
+
+        /**
+         * Whether the skin is locked via a 'lock' directory or not.
+         *
+         * @var string
+         * @see lockSkin(), unlockSkin()
+         */
+
+        protected $locked = false;
+
+        /**
+         * The timestamp used for copies.
+         *
+         * @var string
+         * @see Skin::setStamp();
+         */
+
+        protected $stamp;
+
+        /**
+         * The skin infos to work with as an associative array.
+         *
+         * @var array
+         */
+
+        protected $infos;
+
+        /**
+         * Constructor.
+         *
+         * @param string $skin  The skin name (set the related property);
+         * @param array  $infos Skin infos (set the related property).
+         */
+
+        public function __construct($skin = null, $infos = null)
+        {
+            $skin ? $this->skin = $skin : '';
+            $infos ? $this->infos = $infos : '';
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        final public function skinIsInstalled($copy = false)
+        {
+            if ($this->skin) {
+                if ($this->isInstalled === null) {
+                    $name = strtolower(sanitizeForUrl($this->skin.($copy ? $this->stamp : '')));
+                    $this->isInstalled = self::isInstalled($name);
+                }
+
+                return $this->isInstalled;
+            }
+
+            throw new \Exception('undefined_skin');
+        }
+
+        /**
+         * Whether a skin rox exists or not.
+         *
+         * @return bool
+         */
+
+        public static function isInstalled($skin)
+        {
+            if (static::$installed === null) {
+                return (bool) safe_field('name', 'txp_skin', "name ='".doSlash($skin)."'");
+            } else {
+                return in_array($skin, $installed);
+            }
+        }
+
+        /**
+         * Checks if a skin directory exists and is readable.
+         *
+         * @return string|bool path or false
+         */
+
+        public function isReadable($path = null)
+        {
+            $path = $this->getPath($path);
+
+            return self::isType($path) && is_readable($path);
+        }
+
+        /**
+         * Checks if the Skin directory exists and is writable;
+         * if not, creates it.
+         *
+         * @param  string      $stamp the previously generated timestamp.
+         * @return string|bool        path or false
+         */
+
+        public function isWritable($path = null)
+        {
+            $path = $this->getPath($path);
+
+            return self::isType($path) && is_writable($path);
+        }
+
+        /**
+         * Checks if a directory or file exists.
+         *
+         * @return string|bool path or false
+         */
+
+        public static function isType($path)
+        {
+            $isFile = pathinfo($path, PATHINFO_EXTENSION);
+            $isType = $isFile ? is_file($path) : is_dir($path);
+
+            return $isType;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        final public function lockSkin()
+        {
+            $time_start = microtime(true);
+
+            if ($this->locked) {
+                return true;
+            } else {
+                while (!($locked = $this->mkDir('lock')) && $time < 3) {
+                    sleep(0.5);
+                    $time = microtime(true) - $time_start;
+                }
+
+                if ($locked) {
+                    $this->locked = true;
+                    return $locked;
+                }
+
+                throw new \Exception("unable_to_create_the_skin_lock_directory");
+            }
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        final public function mkDir($path = null)
+        {
+            if (($path = $this->getPath($path)) && $created = @mkdir($path)) {
+                return $created;
+            }
+
+            throw new \Exception(
+                gtxt(
+                    'unable_to_create_skin_directory',
+                    array('{directory}' => basename($path))
+                )
+            );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        final public function unlockSkin()
+        {
+            if ($unlocked = $this->rmDir('lock')) {
+                $this->locked = false;
+                return $unlocked;
+            }
+
+            throw new \Exception("unable_to_unlock_the_skin_directory");
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        final public function rmDir($path = null)
+        {
+            if (($path = $this->getPath($path)) && $removed = @rmdir($path)) {
+                return $removed;
+            }
+
+            throw new \Exception(
+                gtxt(
+                    'unable_to_remove_skin_directory',
+                    array('{directory}' => basename($path))
+                )
+            );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public static function getBasePath()
+        {
+            return get_pref('skin_base_path');
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function getPath($path = null)
+        {
+            return self::getBasePath().'/'.
+                sanitizeForUrl($this->skin.$this->stamp).
+                ($path ? '/'.$path : '');
+        }
+    }
+}

--- a/textpattern/vendors/Textpattern/Skin/SkinInterface.php
+++ b/textpattern/vendors/Textpattern/Skin/SkinInterface.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * https://textpattern.io/
+ *
+ * Copyright (C) 2017 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Main Interface
+ *
+ * Implemented by SkinBase.
+ *
+ * @since   4.7.0
+ * @package Skin
+ */
+ 
+namespace Textpattern\Skin {
+
+    interface SkinInterface
+    {
+        /**
+         * Constructor
+         *
+         * @param  string $skin  Skin name;
+         * @param  array  $infos Skin infos;
+         */
+
+        public function __construct($skin = null, $infos = null);
+
+        /**
+         * Tells whether the skin row exists or not.
+         *
+         * @return bool
+         */
+
+        public function skinIsInstalled($copy = false);
+
+        /**
+         * Pseudo locks the skin directory by adding a 'lock' directory
+         * and setting the $locked property.
+         *
+         * @return bool
+         */
+
+        public function lockSkin();
+
+        /**
+         * Creates a directory.
+         *
+         * @throws \Exception
+         */
+
+        public function mkDir($path = null);
+
+        /**
+         * Pseudo unlocks the skin directory by emoving the 'lock' directory
+         * and resetting the $locked property.
+         *
+         * @return bool
+         */
+
+        public function unlockSkin();
+
+        /**
+         * Removes a directory.
+         *
+         * @throws \Exception
+         */
+
+        public function rmDir($path = null);
+
+        /**
+         * Gets the skin or asset related directory path.
+         *
+         * @param  string $basename String to add to the skin path ($dir property by default);
+         * @return string           The path
+         */
+
+        public function getPath($basename = null);
+
+        /**
+         * Creates the skin and/or its asset related templates.
+         *
+         * @throws \Exception
+         */
+    }
+}

--- a/textpattern/vendors/Textpattern/Skin/Styles.php
+++ b/textpattern/vendors/Textpattern/Skin/Styles.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Textpattern Content Management System
+ * https://textpattern.io/
+ *
+ * Copyright (C) 2017 The Textpattern Development Team
+ *
+ * This file is part of Textpattern.
+ *
+ * Textpattern is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, version 2.
+ *
+ * Textpattern is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Textpattern. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Styles
+ *
+ * Manages skin styles directly or via the Skin class.
+ *
+ * @since   4.7.0
+ * @package Skin
+ * @see     AssetInterface
+ */
+
+namespace Textpattern\Skin {
+
+    class Styles extends Pages
+    {
+        protected static $dir = 'styles';
+        protected static $table = 'txp_css';
+        protected static $columns = array('skin', 'name', 'css');
+        protected static $extension = 'css';
+        protected static $essential = array('default');
+
+        /**
+         * {@inheritdoc}
+         */
+
+        public function exportTemplate($row)
+        {
+            extract($row);
+
+            return (bool) file_put_contents(
+                $this->getPath(static::$dir.'/'.$name.'.'.static::$extension),
+                $css
+            );
+        }
+    }
+}

--- a/textpattern/vendors/Textpattern/Skin/gb.textpack
+++ b/textpattern/vendors/Textpattern/Skin/gb.textpack
@@ -1,0 +1,13 @@
+#@version 4.7.0
+#@admin
+import_skin => Import a new skin:
+no_new_skin_to_import => No new skin to import.
+skin_not_found => Skin not found: <strong>{skin}</strong>.
+invalid_skin_json_file => Invalid JSON skin file: <strong>{file}</strong>.
+skin_step_succeeded => Skin(s) {step}:
+unable_to_create_skin_directory: {$directory} => Unable to create the <strong>{$directory}</strong> skin directory.
+unable_to_remove_skin_directory: {$directory} => Unable to create the <strong>{$directory}</strong> skin directory.
+skin_step_failed => Skin(s) {step} failed for: <strong>{skins}</strong>.  
+unable_to_delete_skin_in_use => Unable to delete skin in use: <strong>{skin}</strong>.
+skin_step_failed_for_templates => {skin} {asset} {step} failed for: <strong>{templates}</strong>.
+skin_step_failed_for_duplicated_templates => {skin} {asset} {step} failed for: <strong>{templates}</strong> (duplicated forms).


### PR DESCRIPTION
As discussed with @Bloke  and @philwareham by email, here is a pull request introducing an initial Skin package to manage related features. Basics work, advanced features and callbacks still need some tests. Happy debug!

#### Main classes
- [Main](https://github.com/NicolasGraph/textpattern/blob/themes/textpattern/vendors/Textpattern/Skin/Main.php) manages multiple themes features;
- [Skin](https://github.com/NicolasGraph/textpattern/blob/themes/textpattern/vendors/Textpattern/Skin/Skin.php) manages a single theme and its assets (pages, forms and styles);
- [Pages](https://github.com/NicolasGraph/textpattern/blob/themes/textpattern/vendors/Textpattern/Skin/Pages.php) manages a defined skin related pages;
- [Forms](https://github.com/NicolasGraph/textpattern/blob/themes/textpattern/vendors/Textpattern/Skin/Forms.php) manages a defined skin related forms;
- [Styles](https://github.com/NicolasGraph/textpattern/blob/themes/textpattern/vendors/Textpattern/Skin/Styles.php) manages a defined skin related styles.

#### Admin features
- create a new theme with default pages, forms and styles* (was part of txp_skin.php);
- edit an installed theme (was part of txp_skin.php);
- Import/update a theme from flat files;
- duplicate an installed theme;
- export/backup an installed theme as flat files;
- Delete an installed theme which is not in use.

While the Import feature code was inspired by [rah_flat](https://github.com/gocom/rah_flat), it includes changes such as introducing `setMaxDepth` to the `recursiveIteratorIterator` to avoid useless iterations (mainly because of the `composer.json` file introduction) or grouping db queries for better performances.

The skin tab includes the features above for whole themes but the package is ready for defined theme parts manipluation.

[*] _The [`$essential`](https://github.com/NicolasGraph/textpattern/blob/themes/textpattern/vendors/Textpattern/Skin/Forms.php#L42) property of the `Forms` class (also available for `Pages` and `Styles` classes) should be able to replace the [`get_essential_forms()`](https://github.com/textpattern/textpattern/blob/themes/textpattern/lib/txplib_misc.php#L2909) function._ 

#### Theme/skin directory

```
|-- abc_theme
|  +-- composer.json
|  +-- pages
|  |  +-- default.txp
|  |  +-- …
|  +-- forms
|  |  +-- article
|  |  |  +-- default.txp
|  |  |  +-- …
|  |  +-- comment
|  |  +-- …
|  +-- styles
|  |  +-- default.css
|  |  +-- …
```

The theme informations are managed from the `composer.json` file.
Pages and forms accepts the following extensions: `.txp` and `.html`.

#### Misc.

- I changed the theme related event+step couples by editing steps to have something like `skin.import` instead of `skin.skin_import`. While it seems more logical to me I'm not sure about the consistency; other files seem to also include the event name in step names…
- You will find a basic textpack [here](https://github.com/NicolasGraph/textpattern/blob/themes/textpattern/vendors/Textpattern/Skin/gb.textpack).