### PR TITLE
Correct sql query

### DIFF
--- a/textpattern/include/txp_skin.php
+++ b/textpattern/include/txp_skin.php
@@ -188,10 +188,10 @@ function skin_list($message = '')
 
     $rs = safe_rows_start(
         '*,
-            (SELECT COUNT(*) FROM '.safe_pfx_j('txp_section').' s WHERE s.skin = txp_skin.name) section_count,
-            (SELECT COUNT(*) FROM '.safe_pfx_j('txp_page').' p WHERE p.skin = txp_skin.name) page_count,
-            (SELECT COUNT(*) FROM '.safe_pfx_j('txp_form').' f WHERE f.skin = txp_skin.name) form_count,
-            (SELECT COUNT(*) FROM '.safe_pfx_j('txp_css').' c WHERE c.skin = txp_skin.name) css_count',
+            (SELECT COUNT(*) FROM '.safe_pfx_j('txp_section').' WHERE txp_section.skin = txp_skin.name) section_count,
+            (SELECT COUNT(*) FROM '.safe_pfx_j('txp_page').' WHERE txp_page.skin = txp_skin.name) page_count,
+            (SELECT COUNT(*) FROM '.safe_pfx_j('txp_form').' WHERE txp_form.skin = txp_skin.name) form_count,
+            (SELECT COUNT(*) FROM '.safe_pfx_j('txp_css').' WHERE txp_css.skin = txp_skin.name) css_count',
         'txp_skin',
         "{$criteria} order by {$sort_sql} limit {$offset}, {$limit}"
     );


### PR DESCRIPTION
fixed error:
```
User_Error "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 's WHERE s.skin = txp_skin.name) section_count,
            (SELECT COUNT(*) FROM' at line 2"
```

wrong query:
```
SELECT *,
(SELECT COUNT(*) FROM x_txp_section as txp_section s WHERE s.skin = txp_skin.name) section_count,
(SELECT COUNT(*) FROM x_txp_page as txp_page p WHERE p.skin = txp_skin.name) page_count,
(SELECT COUNT(*) FROM x_txp_form as txp_form f WHERE f.skin = txp_skin.name) form_count,
(SELECT COUNT(*) FROM x_txp_css as txp_css c WHERE c.skin = txp_skin.name) css_count FROM x_txp_skin as txp_skin WHERE 1 order by name desc limit 0, 12
```