### PR TITLE
Universal setup: Added check `txp-type`

### DIFF
--- a/textpattern/setup/index.php
+++ b/textpattern/setup/index.php
@@ -958,9 +958,11 @@ function get_public_themes_list()
         foreach  ($files as $file) {
             $file = realpath($file);
             if (preg_match('%^(.*/(\w+))/manifest\.json$%', $file, $mm) && $manifest = @json_decode(file_get_contents($file), true)) {
-                $public_themes[$mm[2]] = $manifest;
-                $public_themes[$mm[2]]['themedir'] = $mm[1];
-                $out[$mm[2]] = empty($manifest['name']) ? $mm[2] : $manifest['name'];
+                if (@$manifest['txp-type'] == 'textpattern-theme') {
+                    $public_themes[$mm[2]] = $manifest;
+                    $public_themes[$mm[2]]['themedir'] = $mm[1];
+                    $out[$mm[2]] = empty($manifest['name']) ? $mm[2] : $manifest['name'];
+                }
             }
         }
     }

--- a/textpattern/setup/manifest.json
+++ b/textpattern/setup/manifest.json
@@ -2,8 +2,7 @@
   "name": "Theme from setup folder",
   "description": "The default theme that ships as standard with Textpattern CMS.",
   "version": "4.7.0-dev",
+  "txp-type":"textpattern-theme",
   "homepage": "https://github.com/textpattern/textpattern-default-theme",
-  "authors": {
-    "name": "Team Textpattern"
-  }
+  "author": "Team Textpattern"
 }


### PR DESCRIPTION
Added check of `txp-type`, so that instead of the theme it was impossible to install a plugin or anything else.
