### PR TITLE
Fix empty() syntax error

### DIFF
--- a/textpattern/vendors/Textpattern/Skin/Main.php
+++ b/textpattern/vendors/Textpattern/Skin/Main.php
@@ -283,7 +283,8 @@ namespace Textpattern\Skin {
         public static function getInstalled()
         {
             if (static::$installed === null) {
-                if (!empty($skins = safe_rows('name, title', 'txp_skin', "1=1"))) {
+                $skins = safe_rows('name, title', 'txp_skin', "1=1");
+                if (!empty($skins)) {
                     static::$installed = array();
 
                     foreach ($skins as $skin) {


### PR DESCRIPTION
PHP 5.4.45
Error:
> Parse error: syntax error, unexpected '=', expecting ')' in /home/vhosts/repo_txp/txp_themes/textpattern/textpattern/vendors/Textpattern/Skin/Main.php on line 286

---
[php function empty()](http://php.net/manual/en/function.empty.php)

> Prior to PHP 5.5, **empty() only supports variables**; anything else will result in a parse error. In other words, the following will not work: empty(trim($name)). Instead, use trim($name) == false.
