### PR TITLE
Skin table/JSON fields consistency

### DIFF
--- a/textpattern/include/txp_skin.php
+++ b/textpattern/include/txp_skin.php
@@ -247,7 +247,7 @@ function skin_list($message = '')
                 'crit'          => $crit,
             );
 
-            $author = ($skin_website) ? href(txpspecialchars($skin_author), $skin_website) : txpspecialchars($skin_author);
+            $author = ($skin_author_uri) ? href(txpspecialchars($skin_author), $skin_author_uri) : txpspecialchars($skin_author);
 
             if ($skin_section_count > 0) {
                 $sectionLink = href(
@@ -365,7 +365,7 @@ function skin_edit($message = null)
         'name',
     )));
 
-    $fields = array('name', 'title', 'version', 'description', 'author', 'website');
+    $fields = array('name', 'title', 'version', 'description', 'author', 'author_uri');
 
     if ($name && $step == 'edit') {
         try {
@@ -393,7 +393,7 @@ function skin_edit($message = null)
             $input = text_area($field, 0, 0, $current, "skin_$field");
         } else {
             $required = ($field === 'name') ? true : false;
-            $type = ($field === 'website') ? 'url' : 'text';
+            $type = ($field === 'author_uri') ? 'url' : 'text';
             $input = fInput($type, $field, $current, '', '', '', INPUT_REGULAR, '', "skin_$field", false, $required);
         }
 
@@ -431,7 +431,7 @@ function skin_save()
         'version',
         'description',
         'author',
-        'website',
+        'author_uri',
     )));
 
     if ($skin = $infos['old_name']) {

--- a/textpattern/setup/data/txp_skin.xml
+++ b/textpattern/setup/data/txp_skin.xml
@@ -7,7 +7,7 @@
             <version>4.7.0</version>
             <description>Textpattern default theme.</description>
             <author>Team Textpattern</author>
-            <website>https://textpattern.com/</website>
+            <author_uri>https://textpattern.com/</author_uri>
         </item>
     </skin>
 </resources>

--- a/textpattern/update/_to_4.7.0.php
+++ b/textpattern/update/_to_4.7.0.php
@@ -54,7 +54,7 @@ safe_create('txp_skin', "
     version     VARCHAR(255)       NULL DEFAULT '1.0',
     description VARCHAR(10240)     NULL DEFAULT '',
     author      VARCHAR(255)       NULL DEFAULT '',
-    website     VARCHAR(255)       NULL DEFAULT '',
+    author_uri  VARCHAR(255)       NULL DEFAULT '',
     lastmod     DATETIME           NULL DEFAULT NULL,
 
     PRIMARY KEY (`name`(50))
@@ -128,7 +128,7 @@ if (!$exists) {
         title = 'Default',
         version = '".txp_version."',
         author = 'Team Textpattern',
-        website = 'https://textpattern.com/'"
+        author_uri = 'https://textpattern.com/'"
     );
 }
 

--- a/textpattern/vendors/Textpattern/DB/Tables/txp_skin.table
+++ b/textpattern/vendors/Textpattern/DB/Tables/txp_skin.table
@@ -3,7 +3,7 @@ title       VARCHAR(255)   NOT NULL DEFAULT 'Default',
 version     VARCHAR(255)       NULL DEFAULT '1.0',
 description VARCHAR(10240)     NULL DEFAULT '',
 author      VARCHAR(255)       NULL DEFAULT '',
-website     VARCHAR(255)       NULL DEFAULT '',
+author_uri  VARCHAR(255)       NULL DEFAULT '',
 lastmod     DATETIME           NULL DEFAULT NULL,
 
 PRIMARY KEY (name(50))

--- a/textpattern/vendors/Textpattern/Skin/Main.php
+++ b/textpattern/vendors/Textpattern/Skin/Main.php
@@ -237,7 +237,7 @@ namespace Textpattern\Skin {
 
                     if ($name === strtolower(sanitizeForUrl($name))) {
                         $infos = $skin->getTemplateJSONContents();
-                        static::$directories[$name] = $infos['name'];
+                        static::$directories[$name] = $infos['title'];
                     }
                 }
             }

--- a/textpattern/vendors/Textpattern/Skin/Skin.php
+++ b/textpattern/vendors/Textpattern/Skin/Skin.php
@@ -166,7 +166,7 @@ namespace Textpattern\Skin {
                  version = '".doSlash($version ? $version : '0.0.1')."',
                  description = '".doSlash($description)."',
                  author = '".doSlash($author ? $author : substr(cs('txp_login_public'), 10))."',
-                 website = '".doSlash($website)."',
+                 author_uri = '".doSlash($author_uri)."',
                  name = '".doSlash(strtolower(sanitizeForUrl($this->skin)))."'
                 "
             );
@@ -245,7 +245,7 @@ namespace Textpattern\Skin {
                  version = '".doSlash($version)."',
                  description = '".doSlash($description)."',
                  author = '".doSlash($author)."',
-                 website = '".doSlash($website)."'
+                 author_uri = '".doSlash($author_uri)."'
                 ",
                 "name = '".doSlash($this->skin)."'"
             );
@@ -332,11 +332,11 @@ namespace Textpattern\Skin {
 
             return (bool) safe_upsert(
                 self::$table,
-                "title = '".doSlash(isset($name) ? $name : $this->skin)."',
+                "title = '".doSlash(isset($title) ? $title : $this->skin)."',
                  version = '".doSlash(isset($version) ? $version : '')."',
                  description = '".doSlash(isset($description) ? $description : '')."',
                  author = '".doSlash(isset($author) ? $author : '')."',
-                 website = '".doSlash(isset($homepage_url) ? $homepage_url : '')."'
+                 author_uri = '".doSlash(isset($author_uri) ? $author_uri : '')."'
                 ",
                 "name = '".doSlash($this->skin)."'"
             );
@@ -550,12 +550,12 @@ namespace Textpattern\Skin {
 
             $contents = $this->isWritable(static::$file) ? $this->getJSONInfos() : array();
 
-            $contents['name'] = $this->copy ? $this->copy : ($title ? $title : $name);
+            $contents['title'] = $this->copy ? $this->copy : ($title ? $title : $name);
             $contents['txp-type'] = 'textpattern-theme';
             $version ? $contents['version'] = $version : '';
             $description ? $contents['description'] = $description : '';
             $author ? $contents['author'] = $author : '';
-            $website ? $contents['homepage_url'] = $website : '';
+            $author_uri ? $contents['author_uri'] = $author_uri : '';
 
             return (bool) $this->filePutJsonContents($contents);
         }


### PR DESCRIPTION
See https://github.com/textpattern/textpattern/issues/950. 

- Table/JSON field `website`changed to `author_uri`;
- JSON field `name` renamed to `title` (it is what it contains; the theme name comes from its directory name).