### PR TITLE
Tweak `HISTORY.txt` wording, max 80 chars for uniformity.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -6,32 +6,35 @@ Changes in 4.7.0 (upcoming)
   detail' checkboxes. Settings remembered per device.
 * Added: Valueless attributes.
 * Added: Optional short tags.
-* Added: Tag global attributes: 'breakby', 'breakclass', 'class', 'escape', 'html_id',
-  'not' and 'wraptag'.
+* Added: Tag global attributes: 'breakby', 'breakclass', 'class', 'escape',
+  'html_id', 'not' and 'wraptag'.
 * Added: <txp:evaluate /> tag.
-* Added: <txp:header /> tag allows to set HTML headers for page output.
-* Added: <txp:article_custom /> tag can count pages. Enhanced 'month', 'expired' and
-  'time' attributes.
+* Added: <txp:header /> tag allows optional setting of HTML headers on page
+  output.
+* Added: <txp:article_custom /> tag can count pages. Enhanced 'month', 'expired'
+  and time' attributes.
 * Added: XML and JSON file support. Completely overhauled setup procedure to
-  centralise and verify/delete prefs on upgrade. Table structure and preferences
-  defined in files for easier maintenance (thanks, makss).
+  centralise and verify/delete preferences on upgrade. Table structure and
+  preferences defined in files for easier maintenance (thanks, makss).
 * Added: Per-user admin panel language preference (decoupled from site language
   preference).
 * Added: All users can administer their own key biographical info.
-* Added: Button to swap width and height values on image edit thumbnail generator.
+* Added: Button to swap width and height values on image edit thumbnail
+  generator.
 * Added: Multiple files upload with progress meter.
 * Added: Section searches by description.
 * Added: Visual indicator that a subset of search fields are in use.
 * Added: One-click comment searches by parent article (thanks, makss).
 * Added: Diagnostics can remove sensitive path data.
 * Added: 'Expire now' checkbox on Write panel.
-* Changed: Pages, Forms and Styles panels save some changes without page refreshes
-  (Ajax). Last used Page/Form/Stylesheet remembered.
+* Changed: Pages, Forms and Styles panels save some changes without page
+  refreshes (Ajax). Last used Page/Form/Stylesheet remembered.
 * Changed: Articles panel performs searches/pagination without refresh (Ajax).
 * Changed: Forms can recursively (up to 15 deep) call themselves.
 * Changed: <txp:yield> tag now accepts 'name' and 'default' attributes.
-* Changed: <txp:output_form yield /> tag supports user-defined attributes, coupled
-  with <txp:yield> changes above this allows for '<txp::shortcode />'-like tags.
+* Changed: <txp:output_form yield /> tag supports user-defined attributes,
+  coupled with <txp:yield> changes above this allows for '<txp::shortcode />'
+  -like tags.
 * Changed: <txp:page_url /> tag accepts URL variables in 'type' attribute.
 * Changed: <txp:page_title /> tag SEO - site name renders after page name,
   default separator changed from ': ' to ' | ', page numbers added.
@@ -54,17 +57,19 @@ Changes in 4.7.0 (upcoming)
   and its callback removed.
 * Changed: Seamless upgrades: languages also updated automatically.
 * Changed: Further improvements to RTL language support.
-* Changed: Language Textpacks bundled in core instead of using legacy RPC server.
+* Changed: Language Textpacks bundled in core instead of using legacy RPC
+  server.
 * Changed: Use local inline help files instead of legacy RPC server. Help topics
   rendered in dialogs instead of new window (thanks, makss).
-* Changed: Use JSON file to check for new releases/pre-releases instead of legacy
-  RPC server (thanks, makss).
+* Changed: Use JSON file to check for new releases/pre-releases instead of
+  legacy RPC server (thanks, makss).
 * Changed: Plugin Textpacks stored in database and installed on demand.
 * Changed: Plugins have persistent data column available for custom storage.
 * Changed: Clearer plugin list on Diagnostics panel.
 * Changed: Article posted/modified info and ID moved below Title field.
 * Changed: Enable HTTP 226 responses (thanks, da2x).
-* Changed: Make Preference panel and subpanels fully printable (thanks, Philippe).
+* Changed: Make Preference panel and subpanels fully printable (thanks,
+  Philippe).
 * Changed: Panel states stored only client-side (localStorage).
 * Changed: pluggable_ui() behaves more intelligently when chaining.
 * Changed: Pagination steps are more grid friendly: 12/24/48/96.


### PR DESCRIPTION
Some of the 4.7.0 release notes break the 80 character barrier, so I've trimmed.

Obviously ignore this PR if I missed a memo on an increase on the 80 character limit…