### PR TITLE
Proof read `HISTORY.txt`

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,8 +1,8 @@
 Changes in 4.7.0
 
 * In memory of Dean Allen, creator of Textpattern CMS.
-* Added: Support for website themes, stored within the database (accessed via
-  the Themes panel) and available as physical flat file templates for easier
+* Added: Support for website themes, markup stored within the database (accessed
+  via the Themes panel) and available as physical flat file templates for easier
   versioning, portability and installation (many many thanks, NicolasGraph).
 * Added: Support for installation on Nginx web servers.
 * Added: Support for automated installation from CLI.
@@ -29,7 +29,8 @@ Changes in 4.7.0
 * Added: Ability to copy an article without enforced save.
 * Added: Button to swap width and height values on image edit thumbnail
   generator.
-* Added: Ctrl+S/Cmd+S keyboard shortcuts for Submit buttons on any admin panel.
+* Added: Ctrl+S/Cmd+S keyboard shortcuts for Submit, Publish and Save buttons
+  on any admin panel.
 * Added: Multiple files upload with progress meter.
 * Added: Section searches by description.
 * Added: Visual indicator that a subset of search fields are in use.
@@ -41,8 +42,8 @@ Changes in 4.7.0
 * Changed: Pages, Forms and Styles panels save some changes without page
   refreshes (Ajax). Last used Page/Form/Stylesheet remembered.
 * Changed: Articles panel performs searches/pagination without refresh (Ajax).
-* Changed: Forms can recursively (up to 15 deep) call themselves.
-* Changed: <txp:yield> tag now accepts 'name' and 'default' attributes.
+* Changed: Forms can recursively (up to 15 levels deep) call themselves.
+* Changed: <txp:yield> tag accepts 'name' and 'default' attributes.
 * Changed: <txp:output_form yield /> tag supports user-defined attributes,
   coupled with <txp:yield> changes above this allows for '<txp::shortcode />'
   -like tags.
@@ -57,9 +58,10 @@ Changes in 4.7.0
   before <txp:article /> tag.
 * Changed: <txp:site_url /> tag accepts 'type' attribute.
 * Changed: <txp:newer /> and <txp:older /> tags accept 'rel' attribute.
-* Changed: Reinstate <txp:keywords> tag and add wraptag/class/break attributes.
+* Changed: Reinstate <txp:keywords> tag and add 'wraptag', 'class' and 'break'
+  attributes.
 * Changed: Deprecated the 'poplink' attribute on <txp:thumbnail /> tag.
-* Changed: <txp:image_author /> tag now accepts 'id' and 'name' attributes.
+* Changed: <txp:image_author /> tag accepts 'id' and 'name' attributes.
 * Changed: Deprecated <txp:image_display /> and <txp:image_index /> tags, use
   <txp:image /> and <txp:images />, respectively, instead.
 * Changed: Image Edit panel for all users - read-only to some (thanks, phiw13).
@@ -97,8 +99,8 @@ Changes in 4.7.0
 * Changed: Admin theme layout improvements on small devices.
 * Changed: Plugin preview page syntax highlighting and layout improvements.
   Also show Textpack string additions preview (if applicable).
-* Changed: Pages/Forms/styles panels - removed 'Create ...' links when viewing
-  a new, unsaved page/form/style.
+* Changed: Pages/Forms/Styles panels - removed 'Create ...' links when viewing
+  a new, unsaved Page/Form/Style.
 * Developer: 'ahu' constant as multi-site-compatible URL to admin side. Plugin
   authors please use ahu in place of hu.'textpattern'.
 * Fixed: Multi-site setup overhauled: Correct setup and install messages,


### PR DESCRIPTION
Changes proposed in this pull request:

- non-markup theme elements (images etc) are not stored in the database
- Cmd+S works for article Publish and Save, also
- clarified form recursion
- reworded a couple of `now accepts` instances for uniformity – it's clear from the bullet header there's a change, so `now` is unnecessary
- caps case on `Pages`, `Styles` and `Forms`