### PR TITLE
Add info about <4.2.0 jump

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,6 +1,8 @@
 Changes in 4.7.0 (in development)
 
 * In memory of Dean Allen, creator of Textpattern CMS.
+* Textpattern instances older than version 4.2.0 (released 17 Sep 2009) should
+  upgrade to version 4.2.0 before upgrading to version 4.7.0.
 * Added: Support for website themes, markup stored within the database (accessed
   via the Themes panel) and available as flat file templates for easier version
   control, portability and installation (many many thanks, NicolasGraph).


### PR DESCRIPTION
Changes proposed in this pull request:

- update `HISTORY` to add info about ye olde Textpattern-e version jumps

Partially addresses https://github.com/textpattern/textpattern/issues/1257