### PR TITLE
Skin php update

### DIFF
--- a/textpattern/vendors/Textpattern/Skin/AssetBase.php
+++ b/textpattern/vendors/Textpattern/Skin/AssetBase.php
@@ -202,7 +202,7 @@ namespace Textpattern\Skin {
         }
 
         /**
-         * $skin property setter.
+         * $dir property setter.
          *
          * @return object $this The current class object (chainable).
          */

--- a/textpattern/vendors/Textpattern/Skin/Skin.php
+++ b/textpattern/vendors/Textpattern/Skin/Skin.php
@@ -366,82 +366,10 @@ namespace Textpattern\Skin {
             }
 
             if (pathinfo($pathname, PATHINFO_EXTENSION) === 'json') {
-                $contents = self::JSONPrettyPrint(json_encode($contents, TEXTPATTERN_JSON));
+                $contents = json_encode($contents, TEXTPATTERN_JSON | JSON_PRETTY_PRINT);
             }
 
             return file_put_contents($this->getDirPath().DS.$pathname, $contents);
-        }
-
-        /**
-         * Replaces the JSON_PRETTY_PRINT flag in json_encode for PHP versions under 5.4.
-         *
-         * From https://stackoverflow.com/a/9776726
-         *
-         * @param  string $json The JSON contents to prettify;
-         * @return string Prettified JSON contents.
-         */
-
-        protected static function JSONPrettyPrint($json)
-        {
-            $result = '';
-            $level = 0;
-            $in_quotes = false;
-            $in_escape = false;
-            $ends_line_level = null;
-            $json_length = strlen($json);
-
-            for ($i = 0; $i < $json_length; $i++) {
-                $char = $json[$i];
-                $new_line_level = null;
-                $post = "";
-
-                if ($ends_line_level !== null) {
-                    $new_line_level = $ends_line_level;
-                    $ends_line_level = null;
-                }
-
-                if ($in_escape) {
-                    $in_escape = false;
-                } elseif ($char === '"') {
-                    $in_quotes = !$in_quotes;
-                } elseif (! $in_quotes) {
-                    switch ($char) {
-                        case '}':
-                        case ']':
-                            $level--;
-                            $ends_line_level = null;
-                            $new_line_level = $level;
-                            break;
-                        case '{':
-                        case '[':
-                            $level++;
-                        case ',':
-                            $ends_line_level = $level;
-                            break;
-                        case ':':
-                            $post = " ";
-                            break;
-                        case " ":
-                        case "    ":
-                        case "\n":
-                        case "\r":
-                            $char = "";
-                            $ends_line_level = $new_line_level;
-                            $new_line_level = null;
-                            break;
-                    }
-                } elseif ($char === '\\') {
-                    $in_escape = true;
-                }
-
-                if ($new_line_level !== null) {
-                    $result .= "\n".str_repeat("    ", $new_line_level);
-                }
-
-                $result .= $char.$post;
-            }
-
-            return $result;
         }
 
         /**


### PR DESCRIPTION
Hi, Comming back from holidays I see minimum requirements have changed; here is a Skin package related update to use the `JSON_PRETTY_PRINT` flag on `json_encode()` instead of a custom method. It could also be used in `TEXTPATTERN_JSON` directly but I don't think that it is useful for now.

