### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,14 @@ As a development version approaches release, minimum and recommended system
 requirements are confirmed and the production release [system requirements](https://textpattern.com/about/119/system-requirements) will
 be updated accordingly.
 
-The following table outlines anticipated/expected system requirements for
-upcoming releases. It takes into account vendor library support, security
-considerations and other factors.
+The following table outlines anticipated / expected changes to system
+requirements for future releases. It takes into account vendor library support,
+security considerations and other factors. Note that minimum and/or recommended
+versions listed may changed during the development process.
 
 |        |  Minimum<br />(v4.8.0)  | Recommended<br />(v4.8.0) |
 |--------|-------|-----|
-| PHP    | &mdash; | &mdash; |
+| PHP    | 5.5 | 7.2 |
 | MySQL  | &mdash; | &mdash; |
 | Apache | &mdash; | &mdash; |
 | Nginx  | &mdash; | &mdash; |


### PR DESCRIPTION
Changes proposed in this pull request:

- flesh out the upcoming system requirements table a bit

Rationale: expected minimum version for PHP is 5.5 for 4.8.0, and the recommended current mainline PHP (7.2) works perfectly happily with Textpattern release version (4.7.0) and development branch (4.7.1 & 4.8.0).

Three audiences to cater for: a) old PHP people who need a you-need-to-be-this-high-to-ride marker, b) up-to-date PHP people who are wondering if the current PHP works (it does) and c) those in the middle who don't give a rat's pahtooey either way and will ignore this.