### PR TITLE
Fixes $this in static Skin related methods

### DIFF
--- a/textpattern/vendors/Textpattern/Skin/AssetBase.php
+++ b/textpattern/vendors/Textpattern/Skin/AssetBase.php
@@ -210,8 +210,6 @@ namespace Textpattern\Skin {
         protected static function setDir($name)
         {
             static::$dir = $name;
-
-            return $this;
         }
 
         /**
@@ -347,7 +345,7 @@ namespace Textpattern\Skin {
          * @return bool FALSE on error.
          */
 
-        protected static function resetEditing()
+        protected function resetEditing()
         {
             return $this->setEditing(self::getDefault());
         }


### PR DESCRIPTION
Changes proposed in this pull request:

- keep `setDir()` static but do not return `$this`;
- make `resetEditing()` an object related method to support `$this`.

Note that both methods are protected and not in use for now so they are not that useful…

