### PR TITLE
Add `txp-maskable` input class to current password

### DIFF
--- a/textpattern/include/txp_auth.php
+++ b/textpattern/include/txp_auth.php
@@ -164,7 +164,7 @@ function doLoginForm($message)
                     array(
                         'name'         => 'p_password',
                         'autocomplete' => 'current-password',
-                    ), '', '', '', '', INPUT_REGULAR, '', 'login_password', false, true),
+                    ), '', 'txp-maskable', '', '', INPUT_REGULAR, '', 'login_password', false, true),
                 'password', '', array('class' => 'txp-form-field login-password')
             ).
             graf(


### PR DESCRIPTION
See https://github.com/textpattern/textpattern/issues/1377 for background.

Adds a `txp-maskable` input class to current password field. Nothing else.

This should resolve the above issue, though there's a semantics question - should `Show password` be plural since there are two passwords on the panel?

Alternative route might be to have an additional `Show password` checkbox to toggle each input individually - any strong feelings on that @philwareham ?