### PR TITLE
Use smtp_from preference in txpMail() for sender

### DIFF
--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -2776,25 +2776,34 @@ function txpMail($to_address, $subject, $body, $reply_to = null)
 {
     global $txp_user;
 
-    // Send the email as the currently logged in user.
-    if ($txp_user) {
-        $sender = safe_row(
-            "RealName, email",
-            'txp_users',
-            "name = '".doSlash($txp_user)."'"
-        );
-
-        if ($sender && is_valid_email(get_pref('publisher_email'))) {
-            $sender['email'] = get_pref('publisher_email');
-        }
+    $smtp_from = get_pref('smtp_from'); 
+	$site_name = get_pref('sitename');
+    
+    if($smtpFrom) {
+	$sender = array ("RealName" => $site_name,
+						"email" => $smtpFrom);
     }
-    // If not logged in, the receiver is the sender.
     else {
-        $sender = safe_row(
-            "RealName, email",
-            'txp_users',
-            "email = '".doSlash($to_address)."'"
-        );
+        // Send the email as the currently logged in user.
+        if ($txp_user) {
+            $sender = safe_row(
+                "RealName, email",
+                'txp_users',
+                "name = '".doSlash($txp_user)."'"
+            );
+
+            if ($sender && is_valid_email(get_pref('publisher_email'))) {
+                $sender['email'] = get_pref('publisher_email');
+            }
+        }
+        // If not logged in, the receiver is the sender.
+        else {
+            $sender = safe_row(
+                "RealName, email",
+                'txp_users',
+                "email = '".doSlash($to_address)."'"
+            );
+        }
     }
 
     if ($sender) {


### PR DESCRIPTION
I expected "SMTP envelope sender address" configuration value to be used to send the email. When it is used for smtp.mailfrom, Return-Path and envelope-from then why not for From field.

Changes proposed in this pull request:

If "SMTP envelope sender address" is configured then it should be used as sender. Otherwise existing logic of using the logged in user or destination email address as the sender email address will remain. In today's scenario this means all these emails will be treated as spam as they will fail validation since the textpattern server may not have the authorization to send email on behalf of other domains.
