### PR TITLE
tidy up & fix empty theme commentary

### DIFF
--- a/textpattern/vendors/Textpattern/Skin/Css.php
+++ b/textpattern/vendors/Textpattern/Skin/Css.php
@@ -41,7 +41,7 @@ class Css extends AssetBase implements CssInterface
     protected static $essential = array(
         array(
             'name' => 'default',
-            'css' => '/* Contents of the css tag goes here. See https://docs.textpattern.com/tags/css */'
+            'css' => '/* Contents of the \'default\' style goes here. Refer to https://docs.textpattern.com/ for further information. */'
         ),
     );
 

--- a/textpattern/vendors/Textpattern/Skin/Form.php
+++ b/textpattern/vendors/Textpattern/Skin/Form.php
@@ -77,32 +77,32 @@ class Form extends AssetBase implements FormInterface, \Textpattern\Container\Fa
         array(
             'name' => 'comments',
             'type' => 'comment',
-            'Form' => '<!-- Default contents of the comments tag goes here. See https://docs.textpattern.com/tags/comments. -->',
+            'Form' => '<!-- Contents of the \'comments\' comment form goes here. Refer to https://docs.textpattern.com/ for further information. -->',
         ),
         array(
             'name' => 'comments_display',
             'type' => 'comment',
-            'Form' => '<!-- Default contents of the popup_comments tag goes here. See https://docs.textpattern.com/tags/popup_comments. -->',
+            'Form' => '<!-- Contents of the \'comments_display\' comment form goes here. Refer to https://docs.textpattern.com/ for further information. -->',
         ),
         array(
             'name' => 'comment_form',
             'type' => 'comment',
-            'Form' => '<!-- Default contents of the comments_form tag goes here. See https://docs.textpattern.com/tags/comments_form. -->',
+            'Form' => '<!-- Contents of the \'comments_form\' comment form goes here. Refer to https://docs.textpattern.com/ for further information. -->',
         ),
         array(
             'name' => 'default',
             'type' => 'article',
-            'Form' => '<!-- Default contents of the article tag goes here. See https://docs.textpattern.com/tags/article. -->',
+            'Form' => '<!-- Contents of the \'default\' article form goes here. Refer to https://docs.textpattern.com/ for further information. -->',
         ),
         array(
             'name' => 'plainlinks',
             'type' => 'link',
-            'Form' => '<!-- Default contents of the linklist tag goes here. See https://docs.textpattern.com/tags/linklist. -->',
+            'Form' => '<!-- Contents of the \'plainlinks\' link form goes here. Refer to https://docs.textpattern.com/ for further information. -->',
         ),
         array(
             'name' => 'files',
             'type' => 'file',
-            'Form' => '<!-- Default contents of the file_download tag goes here. See https://docs.textpattern.com/tags/file_download. -->',
+            'Form' => '<!-- Contents of the \'files\' file form goes here. Refer to https://docs.textpattern.com/ for further information. -->',
         ),
     );
 

--- a/textpattern/vendors/Textpattern/Skin/Page.php
+++ b/textpattern/vendors/Textpattern/Skin/Page.php
@@ -40,11 +40,11 @@ class Page extends AssetBase implements PageInterface
     protected static $essential = array(
         array(
             'name'      => 'default',
-            'user_html' => '<!-- Contents of the default (home) page template goes here. -->',
+            'user_html' => '<!-- Contents of the \'default\' (home) page template goes here. -->',
         ),
         array(
             'name'      => 'error_default',
-            'user_html' => '<!-- Contents of the standard error page template goes here. -->',
+            'user_html' => '<!-- Contents of the \'error_default\' page template goes here. -->',
         ),
     );
 


### PR DESCRIPTION
first pass at https://github.com/textpattern/textpattern/issues/1766

Changes proposed in this pull request:

- Tidy up
- Remove erroneous references
- Remove links to specific tags in favour of docs landing page

Requesting review from @Bloke or @bloatware since it's PHP territory and the array escaping might not be best practice.
