### PR TITLE
Multisite plugins directory inside site folder

### DIFF
--- a/sites/site1/admin/plugins/.htaccess-dist
+++ b/sites/site1/admin/plugins/.htaccess-dist
@@ -1,0 +1,13 @@
+# BEGIN Textpattern
+
+# Block access to directories without a default document.
+
+<IfModule mod_autoindex.c>
+    Options -Indexes
+</IfModule>
+
+# Inhibit direct file downloads (display 403 Forbidden error) if desired.
+
+# RedirectMatch 403 .*
+
+# END Textpattern

--- a/textpattern/lib/constants.php
+++ b/textpattern/lib/constants.php
@@ -295,12 +295,20 @@ define('PLUGIN_LIFECYCLE_NOTIFY', 0x0002);
 
 define('PLUGIN_RESERVED_FLAGS', 0x0fff);
 
-/**
- * Plugin storage directory.
- */
-
 if (!defined('PLUGINPATH')) {
-    define('PLUGINPATH', txpath.DS.'plugins');
+    /**
+     * Plugin storage directory.
+     *
+     * This constant can be overridden from the config.php.
+     *
+     * @package Files
+     * @example
+     * define('PLUGINPATH', $txpcfg['txpath'] . '/plugins');
+     */
+
+    global $txpcfg;
+    $admin_path = (isset($txpcfg['multisite_root_path'])) ? $txpcfg['multisite_root_path'].DS.'admin' : txpath;
+    define('PLUGINPATH', $admin_path.DS.'plugins');
 }
 
 if (!defined('LOG_REFERER_PROTOCOLS')) {


### PR DESCRIPTION
See Issue #1775 – on multisite installations, save plugins inside the multisite's admin directory.

Changes proposed in this pull request:

- addition of `/plugins` directory inside `/sites/site1/admin/` with corresponding `.htaccess-dist`.
- Set PLUGINPATH constant to be `/sites/{sitename}/admin/plugin` if the site is a multisite installation, otherwise use the regular `textpattern/plugins`location.
