### PR TITLE
Update txp_diag.php

### DIFF
--- a/textpattern/include/txp_diag.php
+++ b/textpattern/include/txp_diag.php
@@ -846,7 +846,7 @@ function checkUpdates()
                 $lastCheck['msgval'] = array('{version}' => $release);
             }
 
-            if (version_compare($version, $prerelease) < 0) {
+            if (!is_null($prerelease) && version_compare($version, $prerelease) < 0) {
                 $lastCheck['msg2'] = 'textpattern_update_available_beta';
                 $lastCheck['msgval2'] = array('{version}' => $prerelease);
             }

--- a/textpattern/include/txp_diag.php
+++ b/textpattern/include/txp_diag.php
@@ -846,7 +846,7 @@ function checkUpdates()
                 $lastCheck['msgval'] = array('{version}' => $release);
             }
 
-            if (!is_null($prerelease) && version_compare($version, $prerelease) < 0) {
+            if (isset($prerelease) && version_compare($version, $prerelease) < 0) {
                 $lastCheck['msg2'] = 'textpattern_update_available_beta';
                 $lastCheck['msgval2'] = array('{version}' => $prerelease);
             }

--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -5264,6 +5264,9 @@ function txp_escape($escape, $thing = '')
             case 'url':
                 $thing = $tidy ? rawurlencode($thing) : urlencode($thing);
                 break;
+            case 'url_title':
+                $thing = stripSpace($thing, 1);
+                break;
             case 'js':
                 $thing = escape_js($thing);
                 break;


### PR DESCRIPTION
Silence PHP 8.1 – Deprecated “passing null to version_compare()” notice on Diagnostics panel when no prerelease exists.

Changes proposed in this pull request:

- only perform prerelease comparison when $prerelease is not null

Addresses issue #1786.