### PR TITLE
Possible fix for CLS due to image element not having width and height

### DIFF
--- a/textpattern/setup/themes/four-point-nine/forms/misc/images.txp
+++ b/textpattern/setup/themes/four-point-nine/forms/misc/images.txp
@@ -5,18 +5,14 @@
 <txp:if_variable name="caption" value="">
 
     <p itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
-        <img loading="lazy" itemprop="url contentUrl" src="<txp:image_url link='0' />" alt="<txp:image_info type='alt' />">
-        <meta itemprop="width" content="<txp:image_info type="w" />">
-        <meta itemprop="height" content="<txp:image_info type="h" />">
+        <img itemprop="url contentUrl" src="<txp:image_url link='0' />" alt="<txp:image_info type='alt' />" width="<txp:image_info type="w" />" height="<txp:image_info type="h" />">
     </p>
 
 <txp:else />
 
     <figure itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
 
-        <img loading="lazy" itemprop="url contentUrl" src="<txp:image_url link='0' />" alt="<txp:image_info type='alt' />">
-        <meta itemprop="width" content="<txp:image_info type="w" />">
-        <meta itemprop="height" content="<txp:image_info type="h" />">
+        <img itemprop="url contentUrl" src="<txp:image_url link='0' />" alt="<txp:image_info type='alt' />" width="<txp:image_info type="w" />" height="<txp:image_info type="h" />">
 
         <!-- you do not need to specify the attribute type="caption" as that is the default setting for <txp:image_info /> tag -->
         <figcaption itemprop="caption">


### PR DESCRIPTION
This is in context of this issue: https://github.com/textpattern/textpattern/issues/1798

The details are present in the reported issue.

Changes proposed in this pull request:

Specify the width and height in the img element instead of separate meta line.

Remove lazy loading because of "Largest Contentful Paint image was lazily loaded" ... "Above-the-fold images that are lazily loaded render later in the page lifecycle, which can delay the largest contentful paint."

For below-the-fold images the browser will do the magic and take care that it does not affect the above-the-fold screen getting ready on time. We can forego the lazy loading tag here as it affects web vitals.