### PR TITLE
Update txp_diag.php / Silence passing null notice

### DIFF
--- a/textpattern/include/txp_diag.php
+++ b/textpattern/include/txp_diag.php
@@ -846,7 +846,7 @@ function checkUpdates()
                 $lastCheck['msgval'] = array('{version}' => $release);
             }
 
-            if (version_compare($version, $prerelease) < 0) {
+            if (isset($prerelease) && version_compare($version, $prerelease) < 0) {
                 $lastCheck['msg2'] = 'textpattern_update_available_beta';
                 $lastCheck['msgval2'] = array('{version}' => $prerelease);
             }


### PR DESCRIPTION
Silence PHP 8.1 – Deprecated “passing null to version_compare()” notice on Diagnostics panel when no prerelease exists.

Changes proposed in this pull request:

- only perform prerelease version comparison when $prerelease is set and not null.

Addresses issue #1786.