### PR TITLE
Rotate/flip thumb if src img has exif orientation

### DIFF
--- a/textpattern/lib/class.thumb.php
+++ b/textpattern/lib/class.thumb.php
@@ -265,32 +265,34 @@ class wet_thumb
             $this->_SRC['width'] = 100;
         }
 
-        // Check exif orientation of source image.
-        $exif = exif_read_data($this->_SRC['file']);
-        if (!empty($exif['Orientation'])) {
-            // Correct thumbnail orientation based on exif value.
-            switch ($exif['Orientation']) {
-                case 3: // upside-down.
-                case 4: // upside-down (mirrored).
-                    $this->_SRC['image'] = imagerotate($this->_SRC['image'], -180, 0);
-                    break;
-                case 5: // rotate-left (mirrored).
-                case 6: // rotate-left.
-                    $this->_SRC['image'] = imagerotate($this->_SRC['image'], -90, 0);
-                    break;
-                case 7: // rotate-right (mirrored).
-                case 8: // rotate-right.
-                    $this->_SRC['image'] = imagerotate($this->_SRC['image'], 90, 0);
-                    break;
-            }
-            // Swap height and width values if thumbnail is rotated by 90°.
-            if (in_array($exif['Orientation'], [5, 6, 7, 8])) {
-                $this->_SRC['width']    = $temp[1];
-                $this->_SRC['height']   = $temp[0];
-            }
-            // Flip thumbnail if exif orientation is mirrored.
-            if (in_array($exif['Orientation'], [2, 5, 7, 4])) {
-                imageflip($this->_SRC['image'], IMG_FLIP_HORIZONTAL);
+        // Check exif orientation of JPEG source image.
+        if ($this->_SRC['type'] == 2) { // JPEG format
+            $exif = exif_read_data($this->_SRC['file']);
+            if (!empty($exif['Orientation'])) {
+                // Correct thumbnail orientation based on exif value.
+                switch ($exif['Orientation']) {
+                    case 3: // upside-down.
+                    case 4: // upside-down (mirrored).
+                        $this->_SRC['image'] = imagerotate($this->_SRC['image'], -180, 0);
+                        break;
+                    case 5: // rotate-left (mirrored).
+                    case 6: // rotate-left.
+                        $this->_SRC['image'] = imagerotate($this->_SRC['image'], -90, 0);
+                        break;
+                    case 7: // rotate-right (mirrored).
+                    case 8: // rotate-right.
+                        $this->_SRC['image'] = imagerotate($this->_SRC['image'], 90, 0);
+                        break;
+                }
+                // Swap height and width values if thumbnail is rotated by 90°.
+                if (in_array($exif['Orientation'], [5, 6, 7, 8])) {
+                    $this->_SRC['width']    = $temp[1];
+                    $this->_SRC['height']   = $temp[0];
+                }
+                // Flip thumbnail if exif orientation is mirrored.
+                if (in_array($exif['Orientation'], [2, 5, 7, 4])) {
+                    imageflip($this->_SRC['image'], IMG_FLIP_HORIZONTAL);
+                }
             }
         }
 
@@ -515,7 +517,7 @@ class wet_thumb
 
         if ($aslink === true) {
             return '<a href="'.((empty($this->linkurl)) ? $this->_SRC['file'] : $this->linkurl).'" '.
-                (($aspopup === true) ? ' target="_blank"' : '').'>'.$imgtag.'</a>';
+                (($aspopup === true) ? ' rel="noopener" target="_blank"' : '').'>'.$imgtag.'</a>';
         }
 
         return $imgtag;

--- a/textpattern/lib/class.thumb.php
+++ b/textpattern/lib/class.thumb.php
@@ -265,6 +265,35 @@ class wet_thumb
             $this->_SRC['width'] = 100;
         }
 
+        // Check exif orientation of source image.
+        $exif = exif_read_data($this->_SRC['file']);
+        if (!empty($exif['Orientation'])) {
+            // Correct thumbnail orientation based on exif value.
+            switch ($exif['Orientation']) {
+                case 3: // upside-down.
+                case 4: // upside-down (mirrored).
+                    $this->_SRC['image'] = imagerotate($this->_SRC['image'], -180, 0);
+                    break;
+                case 5: // rotate-left (mirrored).
+                case 6: // rotate-left.
+                    $this->_SRC['image'] = imagerotate($this->_SRC['image'], -90, 0);
+                    break;
+                case 7: // rotate-right (mirrored).
+                case 8: // rotate-right.
+                    $this->_SRC['image'] = imagerotate($this->_SRC['image'], 90, 0);
+                    break;
+            }
+            // Swap height and width values if thumbnail is rotated by 90°.
+            if (in_array($exif['Orientation'], [5, 6, 7, 8])) {
+                $this->_SRC['width']    = $temp[1];
+                $this->_SRC['height']   = $temp[0];
+            }
+            // Flip thumbnail if exif orientation is mirrored.
+            if (in_array($exif['Orientation'], [2, 5, 7, 4])) {
+                imageflip($this->_SRC['image'], IMG_FLIP_HORIZONTAL);
+            }
+        }
+
         // Check image orientation.
         if ($this->_SRC['width'] >= $this->_SRC['height']) {
             $this->_SRC['format'] = 'landscape';


### PR DESCRIPTION
Changes proposed in this pull request:

- Add check for EXIF orientation metadata in source image
- If yes, rotate thumbnail accordingly + swap height / width values for further processing
- If yes, flip thumbnail accordingly if necessary