### PR TITLE
Self-closing tag ending acc. to doctype setting

### DIFF
--- a/textpattern/include/txp_tag.php
+++ b/textpattern/include/txp_tag.php
@@ -2351,7 +2351,7 @@ class BuilderTags
 
                     $out .= $this->tdb(
                         ($wraptag ? "<$wraptag>" : '').
-                        '<img src="'.$url.'" width="'.$w.'" height="'.$h.'"'.$alternate.$cap.$htmlid.$cls.$inlinestyle.(get_pref('doctype') == 'html5' ? '>' : ' />').
+                        '<img src="'.$url.'" width="'.$w.'" height="'.$h.'"'.$alternate.$cap.$htmlid.$cls.$inlinestyle.(get_pref('doctype') === 'html5' ? '>' : ' />').
                         ($wraptag ? "</$wraptag>" : '')
                     );
                     break;

--- a/textpattern/include/txp_tag.php
+++ b/textpattern/include/txp_tag.php
@@ -2351,7 +2351,7 @@ class BuilderTags
 
                     $out .= $this->tdb(
                         ($wraptag ? "<$wraptag>" : '').
-                        '<img src="'.$url.'" width="'.$w.'" height="'.$h.'"'.$alternate.$cap.$htmlid.$cls.$inlinestyle.' />'.
+                        '<img src="'.$url.'" width="'.$w.'" height="'.$h.'"'.$alternate.$cap.$htmlid.$cls.$inlinestyle.(get_pref('doctype') == 'html5' ? '>' : ' />').
                         ($wraptag ? "</$wraptag>" : '')
                     );
                     break;

--- a/textpattern/lib/txplib_html.php
+++ b/textpattern/lib/txplib_html.php
@@ -954,7 +954,7 @@ function tag($content, $tag, $atts = '')
 
 function tag_void($tag, $atts = '')
 {
-    return '<'.$tag.join_atts($atts).' />';
+    return '<'.$tag.join_atts($atts).(get_pref('doctype') == 'html5' ? '>' : ' />');
 }
 
 /**
@@ -1877,7 +1877,7 @@ function doWrap($list, $wraptag = null, $break = null, $class = null, $breakclas
     }
     // Non-enclosing breaks.
     elseif ($break === 'br' || $break === 'hr') {
-        $content = join("<$break $breakatts/>".n, $list);
+        $content = join("<$break $breakatts".(get_pref("doctype") == "html5" ? ">" : " />").n, $list);
     } elseif (!preg_match('/^\w[\w\:\-\.]*$/', $break)) {
         $content = join($break, $list);
     } else {
@@ -1925,7 +1925,7 @@ function doTag($content, $tag, $class = '', $atts = '', $id = '')
         $atts .= ' class="'.txpspecialchars($class).'"';
     }
 
-    return (string)$content !== '' ? tag($content, $tag, $atts) : "<$tag $atts />";
+    return (string)$content !== '' ? tag($content, $tag, $atts) : "<$tag $atts".(get_pref("doctype") == "html5" ? ">" : " />");
 }
 
 /**
@@ -1947,7 +1947,7 @@ function doTag($content, $tag, $class = '', $atts = '', $id = '')
 function doLabel($label = '', $labeltag = '')
 {
     if ($label) {
-        return (empty($labeltag) ? $label.'<br />' : tag($label, $labeltag));
+        return (empty($labeltag) ? $label.'<br'.(get_pref('doctype') == 'html5' ? '>' : ' />') : tag($label, $labeltag));
     }
 
     return '';

--- a/textpattern/lib/txplib_html.php
+++ b/textpattern/lib/txplib_html.php
@@ -954,7 +954,7 @@ function tag($content, $tag, $atts = '')
 
 function tag_void($tag, $atts = '')
 {
-    return '<'.$tag.join_atts($atts).(get_pref('doctype') == 'html5' ? '>' : ' />');
+    return '<'.$tag.join_atts($atts).(get_pref('doctype') === 'html5' ? '>' : ' />');
 }
 
 /**
@@ -1877,7 +1877,7 @@ function doWrap($list, $wraptag = null, $break = null, $class = null, $breakclas
     }
     // Non-enclosing breaks.
     elseif ($break === 'br' || $break === 'hr') {
-        $content = join("<$break $breakatts".(get_pref("doctype") == "html5" ? ">" : " />").n, $list);
+        $content = join("<$break $breakatts".(get_pref('doctype') === 'html5' ? ">" : " />").n, $list);
     } elseif (!preg_match('/^\w[\w\:\-\.]*$/', $break)) {
         $content = join($break, $list);
     } else {
@@ -1925,7 +1925,7 @@ function doTag($content, $tag, $class = '', $atts = '', $id = '')
         $atts .= ' class="'.txpspecialchars($class).'"';
     }
 
-    return (string)$content !== '' ? tag($content, $tag, $atts) : "<$tag $atts".(get_pref("doctype") == "html5" ? ">" : " />");
+    return (string)$content !== '' ? tag($content, $tag, $atts) : "<$tag $atts".(get_pref('doctype') === 'html5' ? ">" : " />");
 }
 
 /**
@@ -1947,7 +1947,7 @@ function doTag($content, $tag, $class = '', $atts = '', $id = '')
 function doLabel($label = '', $labeltag = '')
 {
     if ($label) {
-        return (empty($labeltag) ? $label.'<br'.(get_pref('doctype') == 'html5' ? '>' : ' />') : tag($label, $labeltag));
+        return (empty($labeltag) ? $label.'<br'.(get_pref('doctype') === 'html5' ? '>' : ' />') : tag($label, $labeltag));
     }
 
     return '';

--- a/textpattern/publish/comment.php
+++ b/textpattern/publish/comment.php
@@ -695,7 +695,7 @@ function input($type, $name, $val, $size = '', $class = '', $tab = '', $chkd = '
         ($class) ? ' class="'.$class.'"'  : '',
         ($tab)   ? ' tabindex="'.$tab.'"' : '',
         ($chkd)  ? ' checked="checked"'   : '',
-        ' />'.n,
+        (get_pref('doctype') == 'html5' ? '>' : ' />').n,
     );
 
     return join('', $o);

--- a/textpattern/publish/comment.php
+++ b/textpattern/publish/comment.php
@@ -695,7 +695,7 @@ function input($type, $name, $val, $size = '', $class = '', $tab = '', $chkd = '
         ($class) ? ' class="'.$class.'"'  : '',
         ($tab)   ? ' tabindex="'.$tab.'"' : '',
         ($chkd)  ? ' checked="checked"'   : '',
-        (get_pref('doctype') == 'html5' ? '>' : ' />').n,
+        (get_pref('doctype') === 'html5' ? '>' : ' />').n,
     );
 
     return join('', $o);

--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -472,7 +472,7 @@ function image($atts)
             $out .= ' loading="'.$loading.'"';
         }
 
-        $out .= ' />';
+        $out .= (get_pref('doctype') == 'html5' ? '>' : ' />');
 
         if ($link && $thumb_) {
             $attribs = '';
@@ -653,7 +653,7 @@ function feed_link($atts, $thing = null)
     $type = ($flavor == 'atom') ? 'application/atom+xml' : 'application/rss+xml';
 
     if ($format == 'link') {
-        return '<link rel="alternate" type="'.$type.'" title="'.$title.'" href="'.$url.'" />';
+        return '<link rel="alternate" type="'.$type.'" title="'.$title.'" href="'.$url.'"'.(get_pref('doctype') == 'html5' ? '>' : ' />');
     }
 
     $txt = ($thing === null ? $label : parse($thing));
@@ -697,7 +697,7 @@ function link_feed_link($atts)
     $type = ($flavor == 'atom') ? 'application/atom+xml' : 'application/rss+xml';
 
     if ($format == 'link') {
-        return '<link rel="alternate" type="'.$type.'" title="'.$title.'" href="'.$url.'" />';
+        return '<link rel="alternate" type="'.$type.'" title="'.$title.'" href="'.$url.'"'.(get_pref('doctype') == 'html5' ? '>' : ' />');
     }
 
     $out = href($label, $url, array(
@@ -1323,7 +1323,7 @@ function popup($atts)
                 '<div>'.
                 $his.
                 n.$out.
-                n.'<noscript><div><input type="submit" value="'.gTxt('go').'" /></div></noscript>'.
+                n.'<noscript><div><input type="submit" value="'.gTxt('go').'"'.(get_pref('doctype') == 'html5' ? '>' : ' />').'</div></noscript>'.
                 n.'</div>'.
                 n.'</form>';
         }
@@ -1594,7 +1594,7 @@ function search_input($atts, $thing = null)
         return $out;
     }
 
-    $sub = (!empty($button)) ? '<input type="submit" value="'.txpspecialchars($button).'" />' : '';
+    $sub = (!empty($button)) ? '<input type="submit" value="'.txpspecialchars($button).'"'.(get_pref('doctype') == 'html5' ? '>' : ' />') : '';
     $id =  (!empty($html_id)) ? ' id="'.txpspecialchars($html_id).'"' : '';
 
     $out = (!empty($label)) ? txpspecialchars($label).br.$out.$sub : $out.$sub;
@@ -3289,7 +3289,7 @@ function article_image($atts)
             ($style ? ' style="'.txpspecialchars($style).'"' : '').
             ($width ? ' width="'.(int) $width.'"' : '').
             ($height ? ' height="'.(int) $height.'"' : '').
-            ' />';
+            (get_pref('doctype') == 'html5' ? '>' : ' />');
 
             $out[] = $img;
     }
@@ -3873,7 +3873,7 @@ function meta_keywords($atts)
 
         if ($format === 'meta') {
             // Can't use tag_void() since it escapes its content.
-            $out = '<meta name="keywords" content="'.$content.'" />';
+            $out = '<meta name="keywords" content="'.$content.'"'.(get_pref('doctype') == 'html5' ? '>' : ' />');
         } else {
             $out = $content;
         }
@@ -3904,7 +3904,7 @@ function meta_description($atts)
         $content = ($escape === true) ? txpspecialchars($content) : txp_escape($escape, $content);
 
         if ($format === 'meta') {
-            $out = '<meta name="description" content="'.$content.'" />';
+            $out = '<meta name="description" content="'.$content.'"'.(get_pref('doctype') == 'html5' ? '>' : ' />');
         } else {
             $out = $content;
         }
@@ -3951,7 +3951,7 @@ function meta_author($atts)
 
         if ($format === 'meta') {
             // Can't use tag_void() since it escapes its content.
-            $out = '<meta name="author" content="'.$display_name.'" />';
+            $out = '<meta name="author" content="'.$display_name.'"'.(get_pref('doctype') == 'html5' ? '>' : ' />');
         } else {
             $out = $display_name;
         }
@@ -4955,7 +4955,7 @@ function rsd()
 
     trigger_error(gTxt('deprecated_tag'), E_USER_NOTICE);
 
-    return ($prefs['enable_xmlrpc_server']) ? '<link rel="EditURI" type="application/rsd+xml" title="RSD" href="'.hu.'rpc/" />' : '';
+    return ($prefs['enable_xmlrpc_server']) ? '<link rel="EditURI" type="application/rsd+xml" title="RSD" href="'.hu.'rpc/"'.(get_pref('doctype') == 'html5' ? '>' : ' />') : '';
 }
 
 // -------------------------------------------------------------

--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -468,11 +468,11 @@ function image($atts)
             $out .= ' height="'.(int) $height.'"';
         }
 
-        if ($loading && $doctype == 'html5' && in_array($loading, array('auto', 'eager', 'lazy'))) {
+        if ($loading && $doctype === 'html5' && in_array($loading, array('auto', 'eager', 'lazy'))) {
             $out .= ' loading="'.$loading.'"';
         }
 
-        $out .= (get_pref('doctype') == 'html5' ? '>' : ' />');
+        $out .= (get_pref('doctype') === 'html5' ? '>' : ' />');
 
         if ($link && $thumb_) {
             $attribs = '';
@@ -653,7 +653,7 @@ function feed_link($atts, $thing = null)
     $type = ($flavor == 'atom') ? 'application/atom+xml' : 'application/rss+xml';
 
     if ($format == 'link') {
-        return '<link rel="alternate" type="'.$type.'" title="'.$title.'" href="'.$url.'"'.(get_pref('doctype') == 'html5' ? '>' : ' />');
+        return '<link rel="alternate" type="'.$type.'" title="'.$title.'" href="'.$url.'"'.(get_pref('doctype') === 'html5' ? '>' : ' />');
     }
 
     $txt = ($thing === null ? $label : parse($thing));
@@ -697,7 +697,7 @@ function link_feed_link($atts)
     $type = ($flavor == 'atom') ? 'application/atom+xml' : 'application/rss+xml';
 
     if ($format == 'link') {
-        return '<link rel="alternate" type="'.$type.'" title="'.$title.'" href="'.$url.'"'.(get_pref('doctype') == 'html5' ? '>' : ' />');
+        return '<link rel="alternate" type="'.$type.'" title="'.$title.'" href="'.$url.'"'.(get_pref('doctype') === 'html5' ? '>' : ' />');
     }
 
     $out = href($label, $url, array(
@@ -1323,7 +1323,7 @@ function popup($atts)
                 '<div>'.
                 $his.
                 n.$out.
-                n.'<noscript><div><input type="submit" value="'.gTxt('go').'"'.(get_pref('doctype') == 'html5' ? '>' : ' />').'</div></noscript>'.
+                n.'<noscript><div><input type="submit" value="'.gTxt('go').'"'.(get_pref('doctype') === 'html5' ? '>' : ' />').'</div></noscript>'.
                 n.'</div>'.
                 n.'</form>';
         }
@@ -1573,7 +1573,7 @@ function search_input($atts, $thing = null)
         $out = parse($thing);
         $outside = $oldatts;
     } else {
-        $h5 = ($doctype == 'html5');
+        $h5 = ($doctype === 'html5');
         $out = fInput(
             $h5 ? 'search' : 'text',
             array(
@@ -1594,7 +1594,7 @@ function search_input($atts, $thing = null)
         return $out;
     }
 
-    $sub = (!empty($button)) ? '<input type="submit" value="'.txpspecialchars($button).'"'.(get_pref('doctype') == 'html5' ? '>' : ' />') : '';
+    $sub = (!empty($button)) ? '<input type="submit" value="'.txpspecialchars($button).'"'.(get_pref('doctype') === 'html5' ? '>' : ' />') : '';
     $id =  (!empty($html_id)) ? ' id="'.txpspecialchars($html_id).'"' : '';
 
     $out = (!empty($label)) ? txpspecialchars($label).br.$out.$sub : $out.$sub;
@@ -2278,7 +2278,7 @@ function comment_input($atts, $thing = null, $field = 'name', $clean = false)
 
     $warn = false;
     $val = is_callable($clean) ? $clean(pcs($field)) : pcs($field);
-    $h5 = ($prefs['doctype'] == 'html5');
+    $h5 = ($prefs['doctype'] === 'html5');
     $required = get_pref('comments_require_'.$field);
 
     if (!empty($class)) {
@@ -2339,7 +2339,7 @@ function comment_message_input($atts)
     $attr = join_atts(array(
         'cols'        => intval($cols),
         'rows'        => intval($rows),
-        'required'    => $prefs['doctype'] == 'html5',
+        'required'    => $prefs['doctype'] === 'html5',
         'style'       => $style,
         'aria-label'  => $aria_label,
         'placeholder' => $placeholder
@@ -3279,7 +3279,7 @@ function article_image($atts)
                 ($title && $title !== true ? ' title="'.txpspecialchars($title).'"' : '');
         }
 
-        if ($loading && $doctype == 'html5' && in_array($loading, array('auto', 'eager', 'lazy'))) {
+        if ($loading && $doctype === 'html5' && in_array($loading, array('auto', 'eager', 'lazy'))) {
             $img .= ' loading="'.$loading.'"';
         }
 
@@ -3289,7 +3289,7 @@ function article_image($atts)
             ($style ? ' style="'.txpspecialchars($style).'"' : '').
             ($width ? ' width="'.(int) $width.'"' : '').
             ($height ? ' height="'.(int) $height.'"' : '').
-            (get_pref('doctype') == 'html5' ? '>' : ' />');
+            (get_pref('doctype') === 'html5' ? '>' : ' />');
 
             $out[] = $img;
     }
@@ -3873,7 +3873,7 @@ function meta_keywords($atts)
 
         if ($format === 'meta') {
             // Can't use tag_void() since it escapes its content.
-            $out = '<meta name="keywords" content="'.$content.'"'.(get_pref('doctype') == 'html5' ? '>' : ' />');
+            $out = '<meta name="keywords" content="'.$content.'"'.(get_pref('doctype') === 'html5' ? '>' : ' />');
         } else {
             $out = $content;
         }
@@ -3904,7 +3904,7 @@ function meta_description($atts)
         $content = ($escape === true) ? txpspecialchars($content) : txp_escape($escape, $content);
 
         if ($format === 'meta') {
-            $out = '<meta name="description" content="'.$content.'"'.(get_pref('doctype') == 'html5' ? '>' : ' />');
+            $out = '<meta name="description" content="'.$content.'"'.(get_pref('doctype') === 'html5' ? '>' : ' />');
         } else {
             $out = $content;
         }
@@ -3951,7 +3951,7 @@ function meta_author($atts)
 
         if ($format === 'meta') {
             // Can't use tag_void() since it escapes its content.
-            $out = '<meta name="author" content="'.$display_name.'"'.(get_pref('doctype') == 'html5' ? '>' : ' />');
+            $out = '<meta name="author" content="'.$display_name.'"'.(get_pref('doctype') === 'html5' ? '>' : ' />');
         } else {
             $out = $display_name;
         }
@@ -4955,7 +4955,7 @@ function rsd()
 
     trigger_error(gTxt('deprecated_tag'), E_USER_NOTICE);
 
-    return ($prefs['enable_xmlrpc_server']) ? '<link rel="EditURI" type="application/rsd+xml" title="RSD" href="'.hu.'rpc/"'.(get_pref('doctype') == 'html5' ? '>' : ' />') : '';
+    return ($prefs['enable_xmlrpc_server']) ? '<link rel="EditURI" type="application/rsd+xml" title="RSD" href="'.hu.'rpc/"'.(get_pref('doctype') === 'html5' ? '>' : ' />') : '';
 }
 
 // -------------------------------------------------------------


### PR DESCRIPTION
Changes proposed in this pull request:

Appease the W3C validator…

txp_tag.php
- class BuilderTags (tag builder for html image code)

txplib_html.php
- function: tag_void (used in fInput)
- function: doWrap for br/hr break attributes
- function: doTag when content is empty
- function: doLabel break

comment.php
- function: input (for comments)

taghandlers.php
- function: txp:image
- function: txp:article_image
- function: txp:meta_keywords
- function: txp:meta_description
- function: txp:meta_author
- function: txp:feed_link / link_feed_link
- searchinput + popup
- rsd link

(this patch deviates only slightly from the corresponding patch for the main branch as function doWrap has changed slightly in the dev branch)