### PR TITLE
txp:css format attributes for inline output

### DIFF
--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -240,7 +240,7 @@ function page_title($atts)
 function css($atts)
 {
     global $css, $doctype, $pretext;
-    static $stylebody = null;
+    static $stylebody = array();
 
     extract(lAtts(array(
         'escape' => true,
@@ -274,10 +274,14 @@ function css($atts)
     }
 
     if (empty($format) || $format === "inline") {
-        isset($stylebody[$name.'_'.$theme]) or $stylebody = array(
-            $name.'_'.$theme => safe_field('css', 'txp_css', "name='".doSlash($name)."' AND skin='" . doSlash($theme) . "'")
+        $skinObj = Txp::get('Textpattern\Skin\Skin');
+        $safeName = $skinObj->sanitize($name);
+        $safeTheme = $skinObj->sanitize($theme);
+
+        isset($stylebody[$safeName.'_'.$safeTheme]) or $stylebody = array(
+            $safeName.'_'.$safeTheme => safe_field('css', 'txp_css', "name='".doSlash($safeName)."' AND skin='" . doSlash($safeTheme) . "'")
         );
-        $content = ($escape === true) ? $stylebody[$name.'_'.$theme] : txp_escape($escape, $stylebody[$name.'_'.$theme]);
+        $content = ($escape === true) ? $stylebody[$safeName.'_'.$safeTheme] : txp_escape($escape, $stylebody[$safeName.'_'.$safeTheme]);
     }
 
     switch ($format) {

--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -240,8 +240,10 @@ function page_title($atts)
 function css($atts)
 {
     global $css, $doctype, $pretext;
+    static $stylebody = null;
 
     extract(lAtts(array(
+        'escape' => true,
         'format' => 'url',
         'media'  => 'screen',
         'name'   => $css,
@@ -271,6 +273,13 @@ function css($atts)
         $url = hu.'css.php?n='.urlencode($name).'&t='.urlencode($theme);
     }
 
+    if (empty($format) || $format === "inline") {
+        isset($stylebody[$name.'_'.$theme]) or $stylebody = array(
+            $name.'_'.$theme => safe_field('css', 'txp_css', "name='".doSlash($name)."' AND skin='" . doSlash($theme) . "'")
+        );
+        $content = ($escape === true) ? $stylebody[$name.'_'.$theme] : txp_escape($escape, $stylebody[$name.'_'.$theme]);
+    }
+
     switch ($format) {
         case 'link':
             foreach ((array)$url as $href) {
@@ -282,6 +291,12 @@ function css($atts)
                     'href'  => $href,
                 )).n;
             }
+            break;
+        case '':
+            $out .= $content;
+            break;
+        case 'inline':
+            $out .= (!empty($content)) ? tag($content, 'style') : '';
             break;
         default:
             $out .= txpspecialchars(is_array($url) ? implode(',', $url) : $url);


### PR DESCRIPTION
Changes proposed in this pull request:

- format="" attribute for direct css output.
- format="inline" attribute for output in a <style> tag.
- support for escape attributes for inline output.

The "inline" option is self-explanatory. The empty option allows one to construct an own style tag, for example with a nonce, to construct a style block out of several stylesheets, or to output a stylesheet twice, as is common, for example, when providing dark mode variables for system-set dark mode (e.g. via @media) or user-set dark mode (e.g. via class or data-attribute).

The query is saved in a static variable should the same stylesheet be output more than once.

## Background

The underlying motivation is to allow stylesheet entries in _Presentation › Styles_ to be used as user-editable theme overrides containing CSS custom properties (CSS variables). Often only a few variables are overridden, e.g. brand colours, font-family etc., and are then more easily inserted inline directly in the page head.

See also issues #1394 and #1933 for further context.

Improvements welcome!