### PR TITLE
Restrict slashless tag_void to named HTML5 tags

### DIFF
--- a/textpattern/lib/constants.php
+++ b/textpattern/lib/constants.php
@@ -1020,6 +1020,16 @@ if (!defined('TEXTPATTERN_HASH_LENGTH')) {
   const TXP_TAG = '[\w\-\x80-\xffff]+'; //'[^\x00-\x2c\x2f\x3a-\x3f\x5b-\x5d\x7b-\x7f]+';
 
 /**
+  * Define valid HTML5 void tags
+  *
+  * @since   4.9.0
+  */
+
+const HTML5_VOID_TAGS = array(
+    'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'source', 'track', 'wbr'
+);
+
+/**
  * A tab character.
  *
  * @var string

--- a/textpattern/lib/txplib_html.php
+++ b/textpattern/lib/txplib_html.php
@@ -962,7 +962,9 @@ function tag($content, $tag, $atts = '')
 
 function tag_void($tag, $atts = '')
 {
-    return '<'.$tag.join_atts($atts).(get_pref('doctype') === 'html5' ? '>' : ' />');
+    $tag_close = (in_array($tag, HTML5_VOID_TAGS) && get_pref('doctype') === 'html5') ? '>' : ' />';
+
+    return '<'.$tag.join_atts($atts).$tag_close;
 }
 
 /**


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a constant to hold valid HTML5 void tags
- Restrict slashless tag_void output to those HTML5 tags listed in the constant