### PR TITLE
Pragmatic solution for remaining html5 compliant br break tags

### DIFF
--- a/textpattern/lib/txplib_html.php
+++ b/textpattern/lib/txplib_html.php
@@ -1893,7 +1893,7 @@ function doWrap($list, $wraptag = null, $break = null, $class = null, $breakclas
     }
     // Non-enclosing breaks.
     elseif ($break === 'br' || $break === 'hr') {
-        $content = join("<$break $breakatts".(get_pref('doctype') === 'html5' ? ">" : " />").n, $list);
+        $content = join("<$break".($breakatts ? " ".$breakatts : "").(get_pref('doctype') === 'html5' ? ">" : " />").n, $list);
     } elseif (!preg_match('/^\w[\w\:\-\.]*$/', $break)) {
         $content = join($break, $list);
     } else {

--- a/textpattern/publish/taghandlers.php
+++ b/textpattern/publish/taghandlers.php
@@ -789,7 +789,7 @@ function popup($atts)
                 n . '</select>';
 
             if ($label) {
-                $out = $label . br . $out;
+                $out = $label . (get_pref('doctype') === 'html5' ? '<br>' : '<br />') . $out;
             }
 
             if ($wraptag) {
@@ -826,7 +826,7 @@ function category_list($atts, $thing = null)
 
     extract(lAtts(array(
         'active_class' => '',
-        'break'        => br,
+        'break'        => 'br',
         'categories'   => null,
         'children'     => !isset($atts['categories']) ? 1 : (!empty($atts['parent']) ? true : 0),
         'class'        => __FUNCTION__,
@@ -908,7 +908,7 @@ function section_list($atts, $thing = null)
 
     extract(lAtts(array(
         'active_class'    => '',
-        'break'           => br,
+        'break'           => 'br',
         'class'           => __FUNCTION__,
         'default_title'   => get_pref('sitename'),
         'exclude'         => '',
@@ -1094,7 +1094,7 @@ function search_input($atts, $thing = null)
     $sub = (!empty($button)) ? '<input type="submit" value="' . txpspecialchars($button) . '"' . (get_pref('doctype') === 'html5' ? '>' : ' />') : '';
     $id =  (!empty($html_id)) ? ' id="' . txpspecialchars($html_id) . '"' : '';
 
-    $out = (!empty($label)) ? txpspecialchars($label) . br . $out . $sub : $out . $sub;
+    $out = (!empty($label)) ? txpspecialchars($label) . (get_pref('doctype') === 'html5' ? '<br>' : '<br />') . $out . $sub : $out . $sub;
     $out = ($match === 'exact') ? $out : hInput('m', txpspecialchars($match)) . $out;
     $out = ($wraptag) ? doTag($out, $wraptag, $class) : $out;
 

--- a/textpattern/vendors/Textpattern/Tag/Syntax/Comment.php
+++ b/textpattern/vendors/Textpattern/Tag/Syntax/Comment.php
@@ -37,7 +37,7 @@ class Comment
         global $thisarticle, $thiscomment;
     
         extract(lAtts(array(
-            'break'    => br,
+            'break'    => 'br',
             'class'    => __FUNCTION__,
             'form'     => '',
             'limit'    => 10,

--- a/textpattern/vendors/Textpattern/Tag/Syntax/File.php
+++ b/textpattern/vendors/Textpattern/Tag/Syntax/File.php
@@ -36,7 +36,7 @@ class File
         global $s, $c, $context, $thisfile, $thispage, $pretext;
     
         extract(lAtts(array(
-            'break'       => br,
+            'break'       => 'br',
             'category'    => '',
             'author'      => '',
             'realname'    => '',

--- a/textpattern/vendors/Textpattern/Tag/Syntax/Image.php
+++ b/textpattern/vendors/Textpattern/Tag/Syntax/Image.php
@@ -159,7 +159,7 @@ class Image
         global $c;
     
         lAtts(array(
-            'break'    => br,
+            'break'    => 'br',
             'wraptag'  => '',
             'class'    => __FUNCTION__,
             'category' => $c,
@@ -212,7 +212,7 @@ class Image
             'thumbnail'   => true,
             'size'        => '',
             'auto_detect' => 'article, category, author',
-            'break'       => br,
+            'break'       => 'br',
             'wraptag'     => '',
             'class'       => __FUNCTION__,
             'html_id'     => '',


### PR DESCRIPTION
The `br` constant remains unchanged. 

- Alter remaining public-side tag references to `br` as the default break attribute to `'br'` so they are not processed as the constant.
- Two label-input separators are made html5-compliant.
- Drop extra space when there are no $breakatts for br and hr tags.
