### PR TITLE
Remove 2nd pluggable_ui article_ui › categories

### DIFF
--- a/textpattern/include/txp_article.php
+++ b/textpattern/include/txp_article.php
@@ -1005,7 +1005,7 @@ function article_edit($message = '', $concurrent = false, $refresh_partials = fa
     echo wrapRegion('txp-dates-group', $posted_block . $expires_block, 'txp-dates-group-content', 'date_settings', 'article_dates');
 
     // 'Categories' section.
-    $html_categories = pluggable_ui('article_ui', 'categories', $partials['categories']['html'], $rs);
+    $html_categories = $partials['categories']['html'];
     echo wrapRegion('txp-categories-group', $html_categories, 'txp-categories-group-content', 'categories', 'categories');
 
     // 'Meta' collapsible section.


### PR DESCRIPTION
Changes proposed in this pull request in response to issue https://github.com/textpattern/textpattern/issues/1991:

- duplicate pluggable_ui for `article_ui › categories` removed to prevent double execution of callbacks.

I've followed the existing pattern and kept pluggable_ui in the partial callback function.

(In contrast to my original issue, this seems to be the only case of a duplicate in txp_article)
