### PR TITLE
fix svg height / width estimation

### DIFF
--- a/textpattern/lib/txplib_admin.php
+++ b/textpattern/lib/txplib_admin.php
@@ -415,8 +415,8 @@ function txpgetimagesize($file)
         }
 
         $viewbox = explode(' ', $svg['viewBox']);
-        $width = $viewbox[2] - $viewbox[0];
-        $height = $viewbox[3] - $viewbox[1];
+        $width = (int)$viewbox[2];
+        $height = (int)$viewbox[3];
 
         if ($width <= 0 || $height <= 0) {
             return false;

--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -661,7 +661,7 @@ function txpsvgtopx($svgsize)
 
     switch (substr($matches[2], 0, 2)) {
         case '':
-            return($svgsize);
+            return($matches[1]);
             break;
         case 'pt':
             return($matches[1] * 96 / 72);


### PR DESCRIPTION

The current [txpsvgtopx()](https://github.com/textpattern/textpattern/blob/6b0e931648a83a0bc90b3ceb0ccf690af84a1cfb/textpattern/lib/txplib_misc.php#L654-L685) already does unit conversions should an svg width or height contain a non-px unit. However, if no unit is found, it returns an array rather than the value, causing the upload to be discarded in the next step as the width/height is deemed not numeric.

The current [txpgetimagesize()](https://github.com/textpattern/textpattern/blob/6b0e931648a83a0bc90b3ceb0ccf690af84a1cfb/textpattern/lib/txplib_admin.php#L417-L419) incorrectly calculates an `x-max – x-min` and `y-max – y-min` to determine width and height, however the viewBox attribute values are actually `x-origin, y-origin, width, height`. If the width/height is smaller than the origin start coordinate (unusual but possible), it would results in negative widths/heights, causing the upload to be discarded.

This patch changes:

- txplib_misc.php; function txpsvgtopx(): return a value not an array if no unit is matched.
- txplib_admin.php; function txpgetimagesize(): return correct width and height values from svg viewBox attribute.
