### PR TITLE
Use publisher_email if no sender provided

### DIFF
--- a/textpattern/lib/txplib_misc.php
+++ b/textpattern/lib/txplib_misc.php
@@ -2402,8 +2402,8 @@ function txpMail($to_address, $subject, $body, $reply_to = null, $from = null)
         $sender['RealName'] = get_pref("sitename");
     }
 
-    // Use publisher_email if sender email not set in $from
-    if (!isset($sender['email'])) {
+    // Use publisher_email if sender email is missing / $from email is invalid
+    if (!isset($sender['email']) || !is_valid_email($sender['email'])) {
         $sender['email'] = get_pref('publisher_email');
     }
 


### PR DESCRIPTION
Currently txp will attempt to send emails from the currently logged-in admin user. However, many (the majority now?) hosts no longer allow sending from unrecognised email addresses, and pw reset emails are then blocked.

Changes in this PR:

– If a $from sender email (+ name) hasn't been explicitly specified, always send admin mails from the publisher_email if it is set and valid.
– The current $txpuser is no longer used for sending emails

Starting point: in txpMail, the `$from` attribute can be an `email` string or an `('email', 'Realname')` array.

– Use details from $from if specified
– If Realname not specified, use site_name for name
– If email not specified or $from email is invalid, use `publisher_email` pref
– If publisher email is also invalid, use noreply@site_url